### PR TITLE
Osmo Action 4: re-add 0x07/0x39 WiFi-enable as an OA4-only AP-wake probe

### DIFF
--- a/app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt
@@ -29,11 +29,12 @@ data class CameraModel(
     companion object {
         val DEFAULT = CameraModel("DJI Osmo camera")
         const val ID_OSMO_NANO = 0x0019
+        const val ID_OSMO_ACTION_4 = 0x0014
 
         private val BY_ID: Map<Int, CameraModel> = mapOf(
             0x0010 to CameraModel("Osmo Action 2"),
             0x0012 to CameraModel("Osmo Action 3"),
-            0x0014 to CameraModel("Osmo Action 4"), // pairs + BLE creds, but its AP never comes up (open)
+            ID_OSMO_ACTION_4 to CameraModel("Osmo Action 4"), // pairs + BLE creds, but its AP never comes up (open)
             // Genuine Action 5 Pro on 9004 — tester-confirmed (grid + download). The Xtra rebrand
             // gets flipped to 10004 by resolve(); see the Xtra note below.
             0x0015 to CameraModel("Osmo Action 5 Pro", verified = true),

--- a/app/src/main/java/dev/konraditurbe/osmosis/duml/OsmoCommands.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/duml/OsmoCommands.kt
@@ -37,6 +37,15 @@ object OsmoCommands {
         return DjiMessage(TARGET_APP_TO_WIFI, id, type, payload).encode()
     }
 
+    /**
+     * `0x07/0x39` WiFi-enable, payload `7a` — Mimo sends it in its wake sequence. We dropped it from
+     * the general flow because the Nano rejects it (`e0`) for Mimo too, so it's dead weight there. But
+     * that verdict was Nano-only, and the older Osmo Action 4 (which never brought its AP up via any
+     * path we've tried) predates the era when WiFi was an implicit mode — so it's re-added as an
+     * OA4-only probe (see MainActivity.onPaired). Remove again if the OA4 rejects it as well.
+     */
+    fun wifiEnable39(id: Int = 0x8039): ByteArray = wifiQuery(0x39, byteArrayOf(0x7A), id = id)
+
     // ---- Mimo's BLE session sequence (from an HCI snoop of Mimo waking a sleeping Nano) -------
     //
     // Captured order, once notifications are armed on fff4:

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
@@ -565,6 +565,12 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         // 0x53/0x10 is the one that matters: the camera answers 01 00 00 00 and wakes.
         val c = dev.konraditurbe.osmosis.duml.OsmoCommands
         main.postDelayed({ gattClient?.writeCommand(c.session5310()); logLine("sent 0x53/0x10 (wake)") }, 100)
+        // OA4-only probe: it's the one camera whose AP never came up via 0x53/0x10 or ConnectToWiFi,
+        // and it predates the era when WiFi was an implicit mode, so give it Mimo's 0x07/0x39 too
+        // (right after 0x53/0x10, as Mimo orders it). Gated so no verified model regresses.
+        if (currentModelId == CameraModel.ID_OSMO_ACTION_4) {
+            main.postDelayed({ gattClient?.writeCommand(c.wifiEnable39()); logLine("sent 0x07/0x39 (OA4 WiFi-enable probe)") }, 350)
+        }
         main.postDelayed({ gattClient?.writeCommand(c.wifiQuery(0x07, id = 0x8007)) }, 900)
         main.postDelayed({ gattClient?.writeCommand(c.wifiQuery(0x0E, id = 0x800E)) }, 1400)
         main.postDelayed({

--- a/app/src/test/java/dev/konraditurbe/osmosis/duml/SessionCommandsTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/duml/SessionCommandsTest.kt
@@ -56,4 +56,13 @@ class SessionCommandsTest {
         assertEquals(0x07, receiver(f))
         assertEquals(0x07, cmdSet(f)); assertEquals(0x07, cmdId(f))
     }
+
+    @Test
+    fun `0x07-0x39 wifi-enable is 0x07-0x39 to the wifi subsystem with payload 7a`() {
+        val f = OsmoCommands.wifiEnable39()
+        assertEquals(0x02, sender(f))
+        assertEquals(0x07, receiver(f))
+        assertEquals(0x07, cmdSet(f)); assertEquals(0x39, cmdId(f))
+        assertEquals(listOf(0x7A), payload(f).map { it.toInt() and 0xFF })
+    }
 }


### PR DESCRIPTION
First-ever OA4 contact (a tester's Action 4) got through BLE, pairing and BLE creds cleanly, but its AP never came up -- every WiFi join saw no SSID at all, and ConnectToWiFi twice drew a status=19 link-termination. The OA6 on the same build/phone worked, so it's OA4-specific.

0x07/0x39 was dropped earlier because the Nano rejects it, but that verdict was Nano-only and the build the tester ran (v0.4) never sent it -- so it has never actually been put in front of an OA4. Re-add wifiEnable39() (payload 7a) and fire it right after 0x53/0x10 in the post-pair wake, gated to model 0x0014 so no verified camera changes behaviour. Frame pinned by a test; remove again if the OA4 also rejects it.