### PR TITLE
preview: route LRV/proxy stream logging to the saved log file

### DIFF
--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MediaPreviewActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MediaPreviewActivity.kt
@@ -21,6 +21,7 @@ import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
 import dev.konraditurbe.osmosis.R
 import dev.konraditurbe.osmosis.core.CameraFile
+import dev.konraditurbe.osmosis.core.FileLog
 import dev.konraditurbe.osmosis.core.TrimRange
 import dev.konraditurbe.osmosis.net.HttpClient
 import dev.konraditurbe.osmosis.net.VideoMeta
@@ -36,7 +37,11 @@ import dev.konraditurbe.osmosis.net.VideoMeta
 class MediaPreviewActivity : AppCompatActivity() {
 
     private val main = Handler(Looper.getMainLooper())
-    private val http by lazy { HttpClient(ip) { Log.i("Osmosis", it) } }
+    private val http by lazy { HttpClient(ip) { plog(it) } }
+
+    /** Preview events go to logcat AND the saved log file — otherwise a failed LRV/proxy load is
+     *  invisible in a tester's dumped logs (the file dump only ever captured MainActivity's lines). */
+    private fun plog(s: String) { Log.i("Osmosis", s); FileLog.write(s) }
 
     private lateinit var videoView: VideoView
     private lateinit var photoView: ImageView
@@ -226,6 +231,7 @@ class MediaPreviewActivity : AppCompatActivity() {
         // Pro doesn't list), falling back through to the full-res file. See CameraFile.previewCandidates.
         streamCandidates = file.previewCandidates()
         streamIdx = 0
+        plog("preview ${file.name}: ${streamCandidates.size} candidate(s) ${streamCandidates.joinToString(" | ")}")
         startStream(streamCandidates[streamIdx])
     }
 
@@ -236,11 +242,11 @@ class MediaPreviewActivity : AppCompatActivity() {
      */
     private fun startStream(path: String) {
         val uri = Uri.parse("http://$ip$path")
-        Log.i("Osmosis", "preview stream $uri")
+        plog("preview stream (${streamIdx + 1}/${streamCandidates.size}) $uri")
         videoView.visibility = VideoView.VISIBLE
         videoView.setVideoURI(uri)
         videoView.setOnPreparedListener { mp ->
-            Log.i("Osmosis", "preview PREPARED ${mp.videoWidth}x${mp.videoHeight}")
+            plog("preview PREPARED ${mp.videoWidth}x${mp.videoHeight} dur=${videoView.duration}ms")
             mp.isLooping = true
             spinner.visibility = ProgressBar.GONE
             videoView.start()
@@ -251,13 +257,14 @@ class MediaPreviewActivity : AppCompatActivity() {
             main.post(tick)
         }
         videoView.setOnErrorListener { _, what, extra ->
-            Log.i("Osmosis", "preview ERROR what=$what extra=$extra (candidate ${streamIdx + 1}/${streamCandidates.size}: $path)")
+            plog("preview ERROR what=$what extra=$extra (candidate ${streamIdx + 1}/${streamCandidates.size}: $path)")
             if (streamIdx < streamCandidates.size - 1) {
                 streamIdx++
-                Log.i("Osmosis", "preview falling back to ${streamCandidates[streamIdx]}")
+                plog("preview falling back to ${streamCandidates[streamIdx]}")
                 startStream(streamCandidates[streamIdx])
                 return@setOnErrorListener true
             }
+            plog("preview GAVE UP after ${streamCandidates.size} candidate(s) for ${file.name}")
             showStatus("Can't play this clip ($what/$extra)")
             true
         }


### PR DESCRIPTION
A tester's dumped .log showed nothing about a failed LRV preview because MediaPreviewActivity only ever logged to logcat (Log.i), never to FileLog — so the whole preview stream/prepared/error path was invisible in saved logs.

Route those lines through a plog() that writes both, and log the candidate list up front. Now a dumped log shows exactly which candidate was tried (derived .LRF proxy -> full .MP4), the prepared WxH+duration, or the MediaPlayer what/extra error and each fallback — enough to tell a proxy 404 from a decode failure without needing adb logcat.