### PR TITLE
Restore the unknown-airframe probing for Mini 3 work

### DIFF
--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneFrameCensus.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneFrameCensus.kt
@@ -1,0 +1,77 @@
+package dev.konraditurbe.osmosis.drone
+
+import dev.konraditurbe.osmosis.net.DumlTransport
+
+/**
+ * What an aircraft is *actually* saying, for a model whose session we can't open.
+ *
+ * The existing diagnostics answer one question — "did a `0x51/0x13` beacon arrive?" — and on a Mavic 3
+ * that was enough, because everything it pushes is tunnelled inside `0x51/0x01`. On an unknown model
+ * `0x51 inner cmds seen: NONE` is a dead end: it says the aircraft doesn't talk like a Mavic without
+ * saying what it *does* do, and those need completely different fixes.
+ *
+ * So census everything until we have a serial: every CRC-valid frame by cmdset/cmd (nested ones
+ * included), the raw head of each transport packet type, and — the useful part — **any payload
+ * containing a serial-shaped run**. A DJI serial is 12–24 uppercase alphanumerics, distinctive enough
+ * that finding one tells us which frame carries it on this airframe even when it isn't a `0x51/0x13`.
+ *
+ * Diagnostic only: nothing here latches a serial or changes what we send. A run that merely *looks*
+ * like a serial isn't one, and picking the wrong field would be worse than saying we don't know.
+ */
+class DroneFrameCensus(private val serialFinder: (ByteArray) -> Pair<ByteArray, Int>?) {
+
+    private val frames = HashMap<Int, Int>()            // set<<8|cmd -> count
+    private val samples = LinkedHashMap<Int, ByteArray>()   // set<<8|cmd -> first payload seen
+    private val pktCounts = LinkedHashMap<Int, Int>()       // transport pktType -> count
+    private val pktHeads = LinkedHashMap<Int, ByteArray>()  // transport pktType -> first raw head
+    private val serialHits = LinkedHashMap<Int, String>()   // set<<8|cmd -> the serial-shaped run
+    private var total = 0
+
+    fun record(pktType: Int, datagram: ByteArray) {
+        pktCounts.merge(pktType, 1, Int::plus)
+        pktHeads.putIfAbsent(pktType, datagram.copyOfRange(0, minOf(RAW_HEAD, datagram.size)))
+        for ((set, cmd, payload) in DumlTransport.scanFrames(datagram)) {
+            val key = (set shl 8) or cmd
+            total++
+            frames.merge(key, 1, Int::plus)
+            if (samples.size < MAX_SAMPLES) samples.putIfAbsent(key, payload.copyOfRange(0, minOf(SAMPLE, payload.size)))
+            if (serialHits.size < MAX_SERIAL_HITS && key !in serialHits) {
+                serialFinder(payload)?.let { (serial, tag) ->
+                    serialHits[key] = "%s (%d chars, preceded by 0x%02x)"
+                        .format(String(serial, Charsets.US_ASCII), serial.size, tag)
+                }
+            }
+        }
+    }
+
+    fun isEmpty() = total == 0
+
+    /** Lines for the log, in the order they're most useful to read. */
+    fun report(): List<String> {
+        if (isEmpty() && pktCounts.isEmpty()) return listOf("drone census: nothing received at all")
+        val out = ArrayList<String>()
+        val pkts = pktCounts.entries.sortedBy { it.key }.joinToString(", ") { "pkt%02x×%d".format(it.key, it.value) }
+        out += "drone census: $total DUML frames of ${frames.size} kinds, in [$pkts]"
+        if (frames.isNotEmpty()) {
+            out += "drone census: " + frames.entries.sortedByDescending { it.value }.take(MAX_KINDS)
+                .joinToString("  ") { "%02x/%02x×%d".format(it.key shr 8, it.key and 0xFF, it.value) }
+        }
+        // The one that most likely answers "where does THIS model put its serial?".
+        for ((key, hit) in serialHits) out += "drone census: serial-shaped run in %02x/%02x — %s".format(key shr 8, key and 0xFF, hit)
+        if (serialHits.isEmpty() && total > 0) out += "drone census: no serial-shaped run in any frame payload"
+        for ((key, s) in samples) out += "drone census: sample %02x/%02x = %s".format(key shr 8, key and 0xFF, s.hex())
+        // Raw heads matter when frames DON'T parse: they show the transport/routing bytes verbatim.
+        for ((t, head) in pktHeads) out += "drone census: raw pkt%02x head = %s".format(t, head.hex())
+        return out
+    }
+
+    private fun ByteArray.hex() = joinToString("") { "%02x".format(it) }
+
+    private companion object {
+        const val MAX_KINDS = 20        // histogram entries in the one-line summary
+        const val MAX_SAMPLES = 12      // distinct frame kinds we dump a payload for
+        const val MAX_SERIAL_HITS = 6
+        const val SAMPLE = 48           // payload bytes per sample
+        const val RAW_HEAD = 48         // raw datagram bytes per packet type
+    }
+}

--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DronePairing.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DronePairing.kt
@@ -44,10 +44,15 @@ object DronePairing {
      * The hold is 2 s on most models and 3 s on the newest (DJI's own QuickTransfer setup page splits
      * it that way: Mini 3 Pro / Mini 4 Pro = two seconds, Mini 5 Pro = three), so the prompt gives the
      * range rather than a duration that is wrong on half the line-up.
+     *
+     * The **Mini 3** is the exception and needs its own line: it has no hold-to-confirm at all — the
+     * aircraft must first be put into QuickTransfer mode with *three quick presses* of the power
+     * button. Worth surfacing, since a user holding the button on one gets nothing.
      */
     const val APPROVAL_MESSAGE =
         "The drone's lights should be flashing / chasing around now — that means it got the request.\n\n" +
-            "Press and hold its power button for 2–3 seconds to confirm the connection."
+            "Press and hold its power button for 2–3 seconds to confirm the connection.\n\n" +
+            "On a Mini 3, instead press the power button three times quickly to enter QuickTransfer mode."
 
     /**
      * The setup sequence DJI Fly runs **over BLE** right after pairing a Mavic, replayed verbatim from a

--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneSession.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneSession.kt
@@ -26,6 +26,16 @@ class DroneSession(
     log: (String) -> Unit,
     port: Int = 9003,
     /**
+     * Test hook (`--ez nobeacon true`): ignore the serial the beacon offers, forcing it to come from
+     * the `0x51/0x08` challenge instead.
+     *
+     * Without this the challenge path is **unreachable on the one aircraft that can verify it**: a
+     * Mavic 3 beacons first, [latchDroneSerial] latches and returns early, and the challenge is never
+     * parsed. So a green Mavic run would prove only "not broken", saying nothing about whether the
+     * reactive path works — and that is exactly the path we're about to hand a tester as the fix.
+     */
+    private val ignoreBeaconSerial: Boolean = false,
+    /**
      * The serial + tag already read off the aircraft's BLE identity beacon, if one arrived while
      * pairing. Verified on a Mavic 3: the same `0x51/0x13` beacon lands as a GATT notification ~30 s
      * before the AP exists, so the serial can be in hand before the datalink even opens — no beacon
@@ -34,8 +44,8 @@ class DroneSession(
     knownSerial: Pair<ByteArray, Int>? = null,
 ) : DumlSession(log, port, tcpPoke = false, isDrone = true) {
 
-    /** The serial read off the aircraft's BLE identity beacon, if one arrived while pairing. */
-    private val bleSerial = knownSerial
+    /** The BLE-supplied serial, unless `nobeacon` is forcing it to come off the wire. */
+    private val bleSerial = knownSerial?.takeIf { !ignoreBeaconSerial }
 
     private var droneCursor = 0L
     private val droneSeen = HashSet<Long>()
@@ -346,6 +356,11 @@ class DroneSession(
     /** First `0x51/0x13` payload seen, kept verbatim for the log when the serial can't be read out. */
     @Volatile private var beacon13: ByteArray? = null
 
+    /** Everything the aircraft sends before we have a serial — see [DroneFrameCensus]. Collected on
+     *  every session (it stops the moment a serial latches, so a Mavic pays almost nothing) and only
+     *  printed when the open fails, which is the one time anybody needs it. */
+    private val census = DroneFrameCensus { parseDroneSerial(it) }
+
     /** The serial-shaped run in a beacon payload — see [DroneSerial] for why it's found by shape. */
     internal fun parseDroneSerial(payload: ByteArray): Pair<ByteArray, Int>? = DroneSerial.inPayload(payload)
 
@@ -364,6 +379,7 @@ class DroneSession(
             if (inner != 0x13 && inner != 0x08) continue
             val body = pl.copyOfRange(11, ln - 2)
             if (inner == 0x13 && beacon13 == null) beacon13 = body
+            if (inner == 0x13 && ignoreBeaconSerial) continue   // --ez nobeacon: force the challenge path
             parseDroneSerial(body)?.let { (serial, tag) ->
                 droneSerial = serial
                 serialTag = tag
@@ -379,9 +395,15 @@ class DroneSession(
         val inner = seen51.entries.joinToString(", ") { "0x%02x×%d".format(it.key, it.value) }
         log("datalink: 0x51 inner cmds seen: ${if (inner.isEmpty()) "NONE" else inner}")
         beacon13?.let {
-            log("datalink: a 0x51/0x13 beacon DID arrive but carried no readable serial — payload " +
+            // Don't claim it was unreadable when we're the ones who ignored it — that reads as a
+            // parser bug and sends whoever's debugging this straight down the wrong hole.
+            val why = if (ignoreBeaconSerial) "was ignored on purpose (nobeacon)"
+                      else "carried no readable serial"
+            log("datalink: a 0x51/0x13 beacon DID arrive but $why — payload " +
                 it.copyOfRange(0, minOf(64, it.size)).joinToString("") { b -> "%02x".format(b) })
         }
+        // "NONE" only says this airframe isn't a Mavic. The census says what it IS doing.
+        census.report().forEach { log("datalink: $it") }
     }
 
     /** One `0x51`-channel frame: inner DUML (target 0xe9ee) + the shared 22-byte tail. */
@@ -442,8 +464,9 @@ class DroneSession(
             log("datalink: drone serial ${String(s, Charsets.US_ASCII)} (${s.size} chars, " +
                 "tag 0x%02x) — already known from BLE, no datalink beacon needed".format(tag))
         }
-        val waitUntil = System.currentTimeMillis() + 3000
+        val waitUntil = System.currentTimeMillis() + if (ignoreBeaconSerial) 0 else 3000
         while (droneSerial == null && System.currentTimeMillis() < waitUntil) dronePump(200)
+        if (ignoreBeaconSerial) log("datalink: nobeacon — skipping the beacon fast path on purpose")
 
         // Send the open request whether or not we know a serial. It carries none — and the drone's
         // reply to it is the step-2 challenge, which *names the serial*. Bailing here was circular:
@@ -657,8 +680,13 @@ class DroneSession(
                 val pktType = if (dg.size > 6) dg[6].toInt() and 0xFF else -1
                 if (dg.size > 8 && pktType == 0x01) parseDroneStatus(dg)
                 // The beacon has only ever been *seen* on pktType 0x01 — but "only ever" is one
-                // airframe, so look on every packet type until a serial latches.
-                if (dg.size > 8 && droneSerial == null) latchDroneSerial(dg)
+                // airframe. Until we have a serial, look on every packet type and census what does
+                // arrive; a model that beacons elsewhere was previously invisible, indistinguishable
+                // in the log from one that never beacons at all.
+                if (dg.size > 8 && droneSerial == null) {
+                    latchDroneSerial(dg)
+                    census.record(pktType, dg)
+                }
                 if (sink == null) continue
                 if (!manifestStream) sink.write(dg)
                 else if (dg.size > 20 && (dg[6].toInt() and 0xFF) == 0x03) sink.write(dg, 20, dg.size - 20)

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
@@ -157,9 +157,18 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
     /** `--ez nojoin true` — skip the WiFi join/bind and talk over whatever network is already default. */
     private var noJoin = false
 
+    /** `--ez nobeacon true` — a drone's serial must come from the 0x51/0x08 challenge, not the beacon. */
+    private var noBeaconSerial = false
+
     /** Serial + tag read off the drone's identity beacon over BLE, handed to the datalink session. */
     private var bleDroneSerial: Pair<ByteArray, Int>? = null
     private var pinOverride: String? = null // `--es pin <v>` test hook; wins over the per-model token
+    // `--es appid <v>` — the app *identity* half of SetPairingPIN, overridable without a rebuild.
+    // A device remembers the (identity, token) pair it approved and re-pairs it silently (0x45 -> 0x01);
+    // present an identity it has never seen and it must ask the user again (0x45 -> 0x02), which on a
+    // drone means the power-button hold. That makes this the switch for *testing* the first-run path on
+    // hardware that is already paired.
+    private var appIdOverride: String? = null
 
     // Shown while the camera/drone is waiting for the user to confirm pairing (0x07/45 → 0x02).
     // A camera confirms on its own screen; a drone (e.g. Mavic) needs a ~2 s press of its power button.
@@ -282,10 +291,17 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         // Test hooks: `--es pin <v>` overrides the pairing PIN; `--ez autoscan true` auto-starts
         // a scan (perms permitting) so device testing doesn't depend on tapping. Dormant otherwise.
         intent?.getStringExtra("pin")?.let { pinOverride = it; pairPin = it; logLine("pairPin set to \"$it\"") }
+        intent?.getStringExtra("appid")?.let { appIdOverride = it; logLine("app identity set to \"$it\"") }
         // `--ez nojoin true`: phone is already on the AP via Android WiFi settings, so skip the join +
         // bindProcessToNetwork. Needed to capture our own session — see maybeStartOffload.
         if (intent?.getBooleanExtra("nojoin", false) == true) {
             noJoin = true; logLine("nojoin: will use the current default network, no WiFi join")
+        }
+        // `--ez nobeacon true`: make a drone's serial come from the 0x51/0x08 challenge instead of its
+        // beacon. The only way to exercise that path on a Mavic 3, which beacons first and would
+        // otherwise never reach it — see DroneSession.ignoreBeaconSerial.
+        if (intent?.getBooleanExtra("nobeacon", false) == true) {
+            noBeaconSerial = true; logLine("nobeacon: drone serial must come from the 0x51/0x08 challenge")
         }
         if (intent?.getBooleanExtra("autoscan", false) == true) {
             main.postDelayed({ startCameraScan(select = true) }, 500)
@@ -677,12 +693,13 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
      * answer (older cameras), a fallback timer uses the saved password or prompts. Called once.
      */
     /**
-     * The identity half of SetPairingPIN: DJI Fly's for a drone, the generic one for a camera. Both
-     * call sites (first write + retry) must agree — a device keys its remembered approval on this
-     * string, so two writes with different identities read as two different apps asking to pair.
+     * The identity half of SetPairingPIN: DJI Fly's for a drone, the generic one for a camera, unless
+     * `--es appid <v>` overrides it. Both call sites (first write + retry) must agree — a device keys
+     * its remembered approval on this string, so two writes with different identities read as two
+     * different apps asking to pair.
      */
-    private fun pairIdentity(): String =
-        if (currentModel.isDrone) DronePairing.identifier(getSharedPreferences("osmosis", MODE_PRIVATE))
+    private fun pairIdentity(): String = appIdOverride
+        ?: if (currentModel.isDrone) DronePairing.identifier(getSharedPreferences("osmosis", MODE_PRIVATE))
         else dev.konraditurbe.osmosis.duml.DjiPairMessagePayload.DEFAULT_IDENTIFIER
 
     /**
@@ -885,7 +902,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
                         // flat DCF records instead of CompositePack, /v1 instead of /v2 (ROADMAP #14).
                         // This is the only place in the app that decides which of the two it is.
                         val c: MediaSession =
-                            if (m.isDrone) DroneSession(::logLine, m.datalinkPort, bleDroneSerial)
+                            if (m.isDrone) DroneSession(::logLine, m.datalinkPort, noBeaconSerial, bleDroneSerial)
                             else CameraSession(::logLine, m.datalinkPort, m.tcpPoke)
                         c.onStatus = { s -> main.post { onCameraStatus(s) } }
                         c.onFetchProgress = { fp -> setConnectProgress(60 + fp * 38 / 100) } // 60→98

--- a/app/src/test/java/dev/konraditurbe/osmosis/drone/DroneFrameCensusTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/drone/DroneFrameCensusTest.kt
@@ -1,0 +1,63 @@
+package dev.konraditurbe.osmosis.drone
+
+import dev.konraditurbe.osmosis.duml.DjiMessage
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The census exists for one job: on an airframe that never sends a `0x51/0x13` beacon, say where the
+ * serial *is*. These pin that it finds one outside the Mavic's frame shape.
+ */
+class DroneFrameCensusTest {
+
+    /** Same rule as DroneSession.parseDroneSerial: longest 12–24 run of [0-9A-Z], plus the byte before. */
+    private val finder: (ByteArray) -> Pair<ByteArray, Int>? = { payload ->
+        var best: Pair<ByteArray, Int>? = null
+        var i = 0
+        while (i < payload.size) {
+            val c = payload[i].toInt() and 0xFF
+            if (!((c in 0x30..0x39) || (c in 0x41..0x5A))) { i++; continue }
+            var end = i
+            while (end < payload.size) {
+                val e = payload[end].toInt() and 0xFF
+                if ((e in 0x30..0x39) || (e in 0x41..0x5A)) end++ else break
+            }
+            val len = end - i
+            if (len in 12..24 && len > (best?.first?.size ?: 0)) {
+                best = payload.copyOfRange(i, end) to (if (i > 0) payload[i - 1].toInt() and 0xFF else 0x11)
+            }
+            i = end
+        }
+        best
+    }
+
+    /** A CRC-valid DUML frame the real scanner will accept, wrapped in a plausible 20-byte header. */
+    private fun datagram(set: Int, cmd: Int, payload: ByteArray): ByteArray =
+        ByteArray(20) + DjiMessage(0xE9EE, 1, 0x40 or (set shl 8) or (cmd shl 16), payload).encode()
+
+    @Test fun `finds a serial carried by a frame that is not a 0x51 beacon`() {
+        val census = DroneFrameCensus(finder)
+        // A serial-shaped run behind a 0x24 tag, in an 0x0C/0x22 frame — nothing like a Mavic's beacon.
+        val body = byteArrayOf(0x00, 0x24) + "1581F5FKD24A00ABCDEF".toByteArray(Charsets.US_ASCII) +
+            byteArrayOf(0x00, 0x00)
+        census.record(0x02, datagram(0x0C, 0x22, body))
+
+        val report = census.report().joinToString("\n")
+        assertTrue(report, report.contains("serial-shaped run in 0c/22"))
+        assertTrue(report, report.contains("1581F5FKD24A00ABCDEF"))
+        assertTrue(report, report.contains("preceded by 0x24"))
+    }
+
+    @Test fun `says so plainly when no payload holds a serial`() {
+        val census = DroneFrameCensus(finder)
+        census.record(0x01, datagram(0x02, 0x82, ByteArray(24)))
+        val report = census.report().joinToString("\n")
+        assertTrue(report, report.contains("no serial-shaped run in any frame payload"))
+        assertTrue(report, report.contains("02/82×1"))
+        assertTrue(report, report.contains("pkt01×1"))
+    }
+
+    @Test fun `an aircraft that sends nothing reads as nothing, not as an empty histogram`() {
+        assertTrue(DroneFrameCensus(finder).report().single().contains("nothing received at all"))
+    }
+}

--- a/app/src/test/java/dev/konraditurbe/osmosis/drone/PcapAnalysis.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/drone/PcapAnalysis.kt
@@ -1,0 +1,138 @@
+package dev.konraditurbe.osmosis.drone
+
+import dev.konraditurbe.osmosis.net.DumlTransport
+import org.junit.Test
+import java.io.File
+
+/**
+ * An analysis harness, not a unit test — it reads a PCAPdroid capture of DJI Fly talking to a real
+ * drone and prints what the reference app actually does on the datalink, decoded with *our own*
+ * parser. Any disagreement between this output and the app's behaviour is a bug in the app.
+ *
+ * Skipped unless `-Dosmosis.pcap=<file>` is passed, so it never runs in a normal build:
+ * ```
+ * ./gradlew testDebugUnitTest --tests '*PcapAnalysis*' -Dosmosis.pcap=reference/captures/wifi/x.pcap
+ * ```
+ * Captures live in `reference/` and are gitignored; this file is only useful with one to hand.
+ */
+class PcapAnalysis {
+
+    private fun u16be(b: ByteArray, i: Int) = ((b[i].toInt() and 0xFF) shl 8) or (b[i + 1].toInt() and 0xFF)
+    private fun u16le(b: ByteArray, i: Int) = (b[i].toInt() and 0xFF) or ((b[i + 1].toInt() and 0xFF) shl 8)
+    private fun u32le(b: ByteArray, i: Int): Long =
+        (b[i].toLong() and 0xFF) or ((b[i + 1].toLong() and 0xFF) shl 8) or
+            ((b[i + 2].toLong() and 0xFF) shl 16) or ((b[i + 3].toLong() and 0xFF) shl 24)
+
+    /** One UDP datagram: relative time, whether we sent it, and its payload. */
+    private class Datagram(val tMs: Long, val fromApp: Boolean, val payload: ByteArray)
+
+    /** Walk a LINKTYPE_RAW pcap, yielding UDP datagrams on [port]. */
+    private fun readUdp(file: File, port: Int): List<Datagram> {
+        val b = file.readBytes()
+        require(u32le(b, 0) == 0xA1B2C3D4L) { "not a little-endian pcap: ${"%08x".format(u32le(b, 0))}" }
+        require(u32le(b, 20) == 101L) { "expected LINKTYPE_RAW(101), got ${u32le(b, 20)}" }
+        val out = ArrayList<Datagram>()
+        var off = 24
+        var t0 = -1L
+        while (off + 16 <= b.size) {
+            val ts = u32le(b, off) * 1000 + u32le(b, off + 4) / 1000
+            val caplen = u32le(b, off + 8).toInt()
+            val p = off + 16
+            off = p + caplen
+            if (off > b.size || caplen < 28) continue
+            if ((b[p].toInt() and 0xF0) != 0x40) continue          // IPv4 only
+            if ((b[p + 9].toInt() and 0xFF) != 17) continue        // UDP only
+            val ihl = (b[p].toInt() and 0x0F) * 4
+            val udp = p + ihl
+            if (udp + 8 > b.size) continue
+            val sport = u16be(b, udp); val dport = u16be(b, udp + 2)
+            if (sport != port && dport != port) continue
+            val len = u16be(b, udp + 4)
+            val payload = b.copyOfRange(udp + 8, minOf(udp + len, b.size))
+            if (t0 < 0) t0 = ts
+            // The app is 192.168.2.x; the drone is 192.168.2.1.
+            val fromApp = (b[p + 16].toInt() and 0xFF) == 192 && (b[p + 19].toInt() and 0xFF) == 1
+            out.add(Datagram(ts - t0, fromApp, payload))
+        }
+        return out
+    }
+
+    /** The `0x4a` envelope header of a media payload, if it is one. */
+    private fun envelope(pl: ByteArray): Triple<Int, Int, Int>? {
+        if (pl.size < 10 || (pl[0].toInt() and 0xFF) != 0x4A) return null
+        return Triple(pl[1].toInt() and 0xFF, u16le(pl, 4), u16le(pl, 2) and 0x0FFF)  // subtype, seq, len
+    }
+
+    @Test
+    fun `what does DJI Fly actually do on the datalink`() {
+        val path = System.getenv("OSMOSIS_PCAP") ?: System.getProperty("osmosis.pcap") ?: run {
+            println("PcapAnalysis: skipped (set OSMOSIS_PCAP=<file>)"); return
+        }
+        val f = File(path)
+        if (!f.isFile) { println("PcapAnalysis: no such file $path"); return }
+
+        // udp/9003 drone, 9004 Osmo 360 / Nano / Pocket 3, 10004 Xtra Edge Pro / Action 5 Pro.
+        val port = (System.getenv("OSMOSIS_PORT") ?: "9003").toInt()
+        val grams = readUdp(f, port)
+        println("=== ${f.name}: ${grams.size} datagrams on udp/$port ===")
+
+        val pktTypes = sortedMapOf<Int, Int>()
+        val cmdCounts = sortedMapOf<String, Int>()
+        val mediaEvents = ArrayList<String>()
+        val subtypeSeqs = HashMap<Int, MutableSet<Int>>()
+
+        // Every file-management frame, verbatim. 0x00/0x28 is delete: the request carries the handles
+        // and the trailing selector bytes, the reply its status word. 0x02/0xbf is favourite, which
+        // shares the handle namespace and is the cheapest cross-check that a handle is still valid.
+        val fileOps = ArrayList<String>()
+
+        for (g in grams) {
+            if (g.payload.size > 6) pktTypes.merge(g.payload[6].toInt() and 0xFF, 1, Int::plus)
+            // Frames may sit behind the 8-byte transport + 12-byte routing header; scanFrames is
+            // CRC-verified and byte-at-a-time, so feeding the whole datagram is safe.
+            for ((set, cmd, pl) in DumlTransport.scanFrames(g.payload)) {
+                val dir = if (g.fromApp) "->" else "<-"
+                cmdCounts.merge("$dir %02x/%02x".format(set, cmd), 1, Int::plus)
+                if ((set == 0x00 && cmd == 0x28) || (set == 0x02 && cmd == 0xBF)) {
+                    fileOps.add("%7.2fs %s %02x/%02x  %s"
+                        .format(g.tMs / 1000.0, dir, set, cmd, pl.joinToString("") { "%02x".format(it) }))
+                }
+                if (set != 0x00 || (cmd != 0x26 && cmd != 0x27)) continue
+                val env = envelope(pl) ?: continue
+                val (sub, seq, len) = env
+                subtypeSeqs.getOrPut(sub) { sortedSetOf() }.add(seq)
+                // Only log queries and the head of each reply — a reply is many chunks.
+                val isQuery = g.fromApp
+                val chunk = if (pl.size >= 10) u32le(pl, 6).toInt() else -1
+                if (isQuery || chunk == 0) {
+                    val extra = when (sub) {
+                        0x20 -> " file_index=" + u32le(pl, 10)
+                        0x00 -> " cursor=" + u32le(pl, 10)
+                        0x01 -> " count=" + u32le(pl, 10) + " bytes=" + u32le(pl, 14)
+                        else -> ""
+                    }
+                    // Small frames are control, not data — dump them verbatim so our builders can be
+                    // diffed against the reference byte for byte.
+                    val hex = if (pl.size <= 24) "  [" + pl.joinToString("") { "%02x".format(it) } + "]" else ""
+                    mediaEvents.add("%7.2fs %s 4a sub=%02x seq=%04x len=%d%s%s"
+                        .format(g.tMs / 1000.0, dir, sub, seq, len, extra, hex))
+                }
+            }
+        }
+
+        println("\n-- transport pktTypes --"); pktTypes.forEach { (k, v) -> println("  pkt%02x  %d".format(k, v)) }
+        println("\n-- DUML commands (top 25) --")
+        cmdCounts.entries.sortedByDescending { it.value }.take(25).forEach { println("  ${it.key}  ${it.value}") }
+        println("\n-- 0x4a subtypes seen, and how many distinct seqs each used --")
+        subtypeSeqs.toSortedMap().forEach { (sub, seqs) ->
+            println("  sub=%02x  %d distinct seqs, range %04x..%04x"
+                .format(sub, seqs.size, seqs.min(), seqs.max()))
+        }
+        println("\n-- file management: 0x00/0x28 delete, 0x02/0xbf favourite --")
+        if (fileOps.isEmpty()) println("  (none)") else fileOps.forEach { println("  $it") }
+
+        println("\n-- media timeline (queries + reply heads) --")
+        mediaEvents.take(400).forEach { println("  $it") }
+        println("\n  … ${mediaEvents.size} media events total")
+    }
+}


### PR DESCRIPTION
Same restore as support-neo2 — DroneFrameCensus, PcapAnalysis, `--ez nobeacon`, `--es appid`, and the Mini 3 line in the pairing prompt, which matters here: a Mini 3 has no hold-to-confirm at all and needs three quick presses of the power button to enter QuickTransfer, so a tester holding the button gets nothing.

Starts identical to support-neo2 and is expected to diverge as each airframe's findings land. Branched off main, so it carries the Mavic 3 baseline and the current toolchain. Merge main in to stay current; don't merge this back.