### PR TITLE
CI: never attach the debug APK to a release

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -58,6 +58,10 @@ jobs:
           name: app-debug
           path: app/build/outputs/apk/debug/*.apk
 
+      # Release APK only. The debug build stays an Actions artifact (above) where it is useful
+      # for triage, and never becomes a release asset: it is signed with the debug key, so a tester
+      # who grabs it instead of the real one gets "App not installed" over their existing install.
+      # That happened on v1.3.1-rc1 and had to be cleaned up by hand.
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -66,6 +70,5 @@ jobs:
           draft: true
           files: |
             app/build/outputs/apk/release/*.apk
-            app/build/outputs/apk/debug/*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pushing `v1.3.1-rc1` attached **both** APKs to the release. `app-debug.apk` is signed with the debug key, so a tester who grabs it instead of the real one gets "App not installed" over their existing build — and the release notes promise the same signing key. It was removed by hand; this stops it recurring.

The debug build stays an Actions artifact for triage. It just never becomes a release asset.

One-line removal from the `files:` block; the debug `upload-artifact` step is untouched.

### Separately, not fixed here

`draft: true` did nothing on that tag, because a published release already existed and `action-gh-release` only adds assets to one it finds. So a tag pushed with no release yields a draft needing manual publication, while a tag pushed after one exists silently updates it — same push, two outcomes. Worth deciding on, but it is a behaviour change rather than a bug fix.