### PR TITLE
Osmo Pocket 4 verified; pin both advert formats

### DIFF
--- a/app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt
@@ -68,7 +68,11 @@ data class CameraModel(
             // naming decodes in full (path + ext + delete handle). Note: rejects 0x53/0x10 (e0) but its
             // AP comes up anyway via the 0x00/0x2b session, so the wake is belt-and-suspenders here.
             0x0020 to CameraModel("Osmo Pocket 3", verified = true, singleSdStorage = true),
-            0x0021 to CameraModel("Osmo Pocket 4"),
+            // Tester-confirmed 2026-08-08 on Android 10 (our minSdk): connect, a 45-file internal
+            // manifest, playback held, and downloads the tester rated "same or maybe faster than
+            // Mimo". Its `0x02/0xdc` reports real capacity, unlike the Nano's. Note it advertises
+            // the CLASSIC format while the Pro sibling below uses the newer one — see BleAdvert.
+            0x0021 to CameraModel("Osmo Pocket 4", verified = true),
             // Tester-confirmed 2026-08-07 on 9004 + poke: pair, creds, AP, datalink handshake, a
             // 46-file manifest across two stores, playback held, and 43 MB of a clip transferred over
             // /v2. The transfer then died with the AP, not with the protocol — so the datalink config

--- a/app/src/test/java/dev/konraditurbe/osmosis/ble/BleAdvertTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/ble/BleAdvertTest.kt
@@ -21,6 +21,18 @@ class BleAdvertTest {
     /** OsmoPocket4P-6E55, as logged. Classic bytes are zero; the id lives at [10:12]. */
     private val pocket4Pro = hex("000000ee0004bd6e5620da000010")
 
+    /**
+     * A plain Osmo Pocket 4, from a tester's scan on 2026-08-08. Same payload *length* as its Pro
+     * sibling above, but the classic format: model id populated, new-format flag clear.
+     *
+     *     OP4   21 00 00 be 00 00 ee 8d d9 a0 00 00 00 00   classic 0x0021, flag clear
+     *     OP4P  00 00 00 ee 00 04 bd 6e 56 20 da 00 00 10   classic 0,      flag set -> 218
+     *
+     * So the two formats are chosen per model, not per generation or payload size — which is exactly
+     * why 1.3.0 handled the Pocket 4 and left the Pocket 4 Pro as unknown(0x0000).
+     */
+    private val pocket4 = hex("210000be0000ee8dd9a000000000")
+
     /** Nano shape: model 0x0019 at [0:2], then MAC, then a trailing byte. */
     private val nano = hex("190000c25a8abdc2d803")
 
@@ -82,6 +94,30 @@ class BleAdvertTest {
     fun `all zeroes is not a model`() {
         assertNull(BleAdvert.modelId(hex("0000")))
         assertNull(BleAdvert.modelId(ByteArray(0)))
+    }
+
+    /**
+     * The Pocket 4 resolves by id even though the tester had **renamed** the camera to `MEGG-OP4`.
+     * Nothing in that name matches the model table, so the name fallback would have failed outright;
+     * only the advert's classic id identifies it. Real devices in the wild are renamed.
+     */
+    @Test
+    fun `pocket 4 resolves by id on a renamed camera`() {
+        val d = BleAdvert.decode(pocket4)
+        assertFalse("classic format: the flag bit at payload[5] is clear", d.newFormat)
+        assertEquals(0x0021, d.modelId)
+        assertEquals("OsmoPocket4", BleConstants.MODEL_NAMES[d.modelId])
+        val m = CameraModel.resolve(d.modelId, "MEGG-OP4")
+        assertEquals("Osmo Pocket 4", m.name)
+        assertEquals(9004, m.datalinkPort)
+    }
+
+    /** The pair differ only in which field carries the model — length alone can't tell them apart. */
+    @Test
+    fun `pocket 4 and pocket 4 pro are the same length but different formats`() {
+        assertEquals(pocket4.size, pocket4Pro.size)
+        assertEquals(0x0021, BleAdvert.modelId(pocket4))
+        assertEquals(0x0022, BleAdvert.modelId(pocket4Pro))
     }
 
     @Test


### PR DESCRIPTION
A tester ran a Pocket 4 on 1.3.0 (Android 10, our minSdk): connect, 45-file manifest, playback held, downloads "same or maybe faster than Mimo". Marked `verified`.

### Why it worked where the Pro didn't

```
OP4   21 00 00 be 00 00 ee 8d d9 a0 00 00 00 00   classic 0x0021, flag clear
OP4P  00 00 00 ee 00 04 bd 6e 56 20 da 00 00 10   classic 0,      flag set -> 218
```

Same payload length, model carried in different fields. DJI picks the advert format **per model** — not per generation, not by size. 1.3.0 reads only the classic field, which is exactly why one resolved and the other came up `unknown(0x0000)`. Both real payloads are now fixtures.

### Renamed cameras are real

The tester's unit is called **`MEGG-OP4`**. Nothing there matches the model table, so the name fallback would have failed — only the advert id identified it.

### Pill

This camera's `0x02/0xdc` reports genuine capacity, so the Nano's `0/0` is a Nano quirk, not a decode bug.