### PR TITLE
docs: compact the roadmap, and make MEDIA_PROTOCOL a standalone implementation reference

### DIFF
--- a/MEDIA_PROTOCOL.md
+++ b/MEDIA_PROTOCOL.md
@@ -321,7 +321,7 @@ The `0x00/0x27` tagged record above is the **only** media-list wire format:
 - Request: `40 2f 00 01 0b 00 00 00 [handle:u32-LE] 00 00` — `handle` = the video's manifest delete-handle ([§2](#2-delete-media)).
 - Reply: `00 · 40 2f 00 01 · [len:u32-LE] · [handle:u32-LE] · [count:u8] · 00 · { 00 [startTimeMs:u32-LE] } × count`. Count at reply byte 13, first mark at 16, stride 5.
 - **Read-only**, so it runs inline on the live session. Each mark is a `startTimeMs` (ms); marks read as points (no separate duration).
-- Example replies: a 2-mark clip → `4000, 7000` ms; a 3-mark clip → `1000, 3000, 5000` ms. Handles: Xtra `0x4004xxxx`, Nano `0x4010xxxx` (same command). See ROADMAP #7.
+- Example replies: a 2-mark clip → `4000, 7000` ms; a 3-mark clip → `1000, 3000, 5000` ms. Handles: Xtra `0x4004xxxx`, Nano `0x4010xxxx` (same command). The UI that consumed this is parked on branch `highlights`.
 
 ---
 

--- a/MEDIA_PROTOCOL.md
+++ b/MEDIA_PROTOCOL.md
@@ -1,9 +1,11 @@
 # Osmosis — Media & camera DUML commands
 
-Every DUML command we use / know for browsing, fetching, and controlling media on DJI Osmo cameras
-(WiFi UDP datalink + BLE control).
+An implementation reference for browsing, fetching and controlling media on DJI Osmo cameras (WiFi UDP
+datalink + BLE control) — enough to write a client from scratch, in any language. Everything here was
+reverse-engineered and verified against real hardware or a capture; where something is inferred rather
+than measured, it says so.
 
-Transports: **BLE** = write GATT `fff5`, notify `fff4` (the `[6:8]` msg-id round-trips either way — we encode/decode it **little-endian** and the camera echoes the bytes back, so its true endianness is moot for request/response matching).
+Transports: **BLE** = write GATT `fff5`, notify `fff4` (the `[6:8]` msg-id round-trips either way — encode/decode it **little-endian** and the camera echoes the bytes back, so its true endianness is moot for request/response matching).
 
 > ⚠️ **A bare-metal BLE client needs the GATT setup below before the camera will act on anything.** Get it wrong and the camera ATT-acks every write, silently ignores it, and answers nothing — which reads exactly like an unsupported command, so you will hunt the wrong layer for days. Required:
 > - **Subscribe the CCCDs of BOTH `fff4` and `fff5`** (0xFFF5's is easy to miss if service discovery is range-limited to the write characteristic).
@@ -11,10 +13,10 @@ Transports: **BLE** = write GATT `fff5`, notify `fff4` (the `[6:8]` msg-id round
 > - **`fff5` is WRITE_NO_RSP only** (`props=0x36`) — a Write Request on it is a spec violation.
 > - **Every app→camera frame needs `cmd_type` `0x40`**, never `0x00`.
 > - **MTU 500.** Negotiating 517 makes the camera stop answering *every* request (its NimBLE buffers are sized for 500) — raise the buffer config too or leave it alone.
-> - **Wait for the `0x07/0x45` pairing reply before sending the wake.** Ours arrives at ~+232 ms, far later than the ~+21 ms a Mimo capture suggests.
+> - **Wait for the `0x07/0x45` pairing reply before sending the wake.** It can take ~+232 ms, far later than the ~+21 ms a Mimo capture suggests.
 >
 > **LE encryption/bonding is NOT required**
-**Datalink** = UDP (DJI-standard `9004` + TCP-7001 poke first — Nano, Action 5/6, Pocket 3; the **Xtra Edge Pro**
+**Datalink** = UDP (DJI-standard `9004` + TCP-7001 poke first — Nano, Action 5/6, Pocket 3, Pocket 4, Pocket 4 Pro; the **Xtra Edge Pro**
 rebrand alone speaks `10004` with no poke), DUML wrapped
 in `[8B udp hdr][12B routing hdr][frame]`. Addressing byte `(id<<5)|type`: App `0x02`, Camera `0x01`,
 Gimbal `0x03`, Battery `0x05`, WiFi `0x07`, DM368 `0x08`, plus two session endpoints that are **not** the
@@ -30,7 +32,19 @@ camera by mistake and it answers `e0` (reject) and stays asleep; nothing else hi
 - Cmd ID: `0x26`  (response `0x00/0x27`)
 - Dir / transport: App → Camera(`0x01`), datalink
 - Payload (page 1): `4a002a10 01000000 0000 01000000 2d00 0d0100 ffffffffffffffff 0001000000000000 000000`
-- Response: chunked `0x00/0x27` frames, each payload = `[10B sub-header 4A 01 xx xx <seq:u16LE@6> 00 00][chunk]`. **Strip the sub-header, concat chunks in arrival order** → the manifest.
+- Response: chunked `0x00/0x27` frames, each payload = `[10B sub-header][chunk]`. **Strip the sub-header, concat chunks in arrival order** → the manifest.
+
+| sub-header | field |
+|---|---|
+| `+0` | `0x4A` |
+| `+1` | subtype: `0x04` stream start · **`0x01` data chunk** · `0x03` stream end. Only `0x01` carries manifest bytes; the other two are 10 bytes of sub-header and nothing else. |
+| `+4` | **the request counter, echoed from byte 4 of the `0x00/0x26` that asked for this chunk** — see [per-store split](#two-stores-answered-separately-and-labelled-for-free) |
+| `+6` | `u16-LE` seq (restarts per page, so concatenate in arrival order, never seq-sorted) |
+
+⚠️ **Select chunks by the DUML command (`0x00/0x27`), not by the `4A 01` payload prefix.** The 11-byte
+frame header is `[55][len:2][crc8][target:2][id:2][type][set][cmd]`, so the command is available without
+inspecting the body. `4A 01` alone also matches parameter-subscription pushes ([§8](#8-subscribe-param--the-settings-surface-over-ble)),
+which will corrupt the manifest of any client subscribed to more than a handful of parameters.
 - DUML example: <https://b3yond.d3vl.com/duml/#553704f9020100a04000264a002a10010000000000010000002d000d0100ffffffffffffffff0001000000000000000000000000008185>
 
 #### Paginate the full library
@@ -41,7 +55,7 @@ One `0x00/0x26` returns only the **newest ~45 files** (the `2d` = 45 count at pa
    - Cmd Set / ID: `0x02` / `0x0c`  ·  App → Camera(`0x01`), datalink
    - Payload: `01 01 00 01` = enter playback · `01 01 00 00` = leave
    - DUML example (enter): <https://b3yond.d3vl.com/duml/#55110492020100a040020c01010001b63b>
-2. **Per page send three frames** — `query(cursor=1)` → `trigger` → `query(cursor=pageCursor)`. The **second query's cursor selects the page**; the first (`cursor = 0x00000001`) and the trigger (`4a040e10`) prime the stream.
+2. **Per page send three frames** — `query(cursor=1)` → `trigger` → `query(cursor=pageCursor)`. The **second query's cursor selects the page**; the first (`cursor = 0x00000001`) and the trigger (`4a040e10`) prime the stream. Give the two queries **different counters at byte 4** (e.g. 1 and 2) — that is what lets the single reply stream be split back into per-store answers.
 
 | page | cursor @ bytes 10-13 (u32-LE) | returns |
 |------|-------------------------------|---------|
@@ -51,6 +65,10 @@ One `0x00/0x26` returns only the **newest ~45 files** (the `2d` = 45 count at pa
 
 - Only handles **`≥ 0x40000000`** (video records) advance the cursor — a stray low-namespace handle (a `0x0010xxxx` photo) is skipped so it can't jerk the cursor to the bottom and stall paging.
 - Consecutive pages overlap by exactly the one boundary file, so **dedup by media path** (≈ 44 new per page).
+- **End of the library = a short page.** Ask for 45 (`0x2d` at byte 14) and count the records that come
+  back: fewer than 45 means there are no older files. Mimo instead reads a per-record `isPageLastFile`
+  flag, but that flag sits at **no fixed marker-relative offset** — comparing a known-final page against a
+  known-continuing one separates them at no position — so the record count is the reliable test.
 - Two ways to sequence the pages: **a fresh registered session per page** (simplest, always works), or **inline on one long-lived session** with a correct sliding-window `ackSeq` (see *Datalink transport / sequencing*). Both return the same pages.
 
 DUML examples:
@@ -129,18 +147,52 @@ Each record carries a **marker** the header fields hang off: **videos `03 ff 19 
 | resolution *(video)* | `u8 @ marker − 1` | video-format index → pixel size (table below) |
 | **duration *(video)*** | **`u16-LE @ marker − 4`** (= `head + 4`) | whole **seconds**; = `floor(moov ms / 1000)`. |
 | **width, height *(photo)*** | **`u32-LE`, `+58` / `+62` from the `19 06` pair** | photo pixel dimensions (videos have none here — they use the resolution enum) |
-| ⭐ starTag | `u8 @ [ff\|fe] 19 06 + 9` | favourite flag; the one field also present on photo records |
+| ⭐ starTag | `u8 @ [ff\|fe] 19 06 + 9` | favourite flag — **Nano only**; test `== 1`, never `!= 0` (see below) |
 
-- **Two stores = two lists.** With a card in, the reassembled manifest is **two per-storage lists back to back** — **SD first, then internal** — each opening with its own `[u32-LE count][u32-LE size][u32-LE ts]…` header. The leading count covers only the *first* list; the rest belong to the second. Proven by dumping the same camera with and without a card: the no-card manifest is **byte-identical to the mixed manifest's second list**. The split is taken from the count, which every model writes.
-- **The `/v2?storage=N` HTTP mount = the record handle's `0x40000000` bit**: set → internal → `storage=1`; clear → SD → `storage=0`. Confirm with one HEAD. It is **not** the manifest list ordinal — a single-store camera's one list is group 0 yet can mount at `storage=1`.
+##### Two stores answered separately and labelled for free
 
-| camera | store | handle base | `storage=` |
-|--------|-------|-------------|-----------|
-| Xtra Edge Pro / Action 5 Pro | SD | `0x0004xxxx` | `0` |
-| Xtra Edge Pro / Action 5 Pro | internal | `0x4004xxxx` | `1` |
-| Osmo Nano | internal | `0x4010xxxx` | `1` |
-| Action 6 | internal | `0x4010xxxx` | `1` |
-| Pocket 3 | microSD (only store) | `0x0004xxxx` | `0` |
+**The cursor's top bit is the store selector, and the response counter hands the answer back labelled.**
+Cursor `0x00000001` enumerates the SD card, `0x40000001` the internal store — DJI's own `FileLocation`
+(`SD_CARD=0`, `INTERNAL_STORAGE=1`), which is the *same integer* `/v2?storage=` wants. Send the two
+queries under **different counters at byte 4**, and every `0x00/0x27` chunk echoes that counter at
+sub-header byte 4, so one collected blob splits cleanly into the two stores it contains:
+
+```
+-> 0x00/0x26  byte4=1  cursor=0x00000001     "list the SD card"
+-> 0x00/0x26  byte4=2  cursor=0x40000001     "list internal"
+<- 0x00/0x27  sub-header byte4=1  …          these chunks are the SD answer
+<- 0x00/0x27  sub-header byte4=2  …          these chunks are the internal answer
+```
+
+This costs no extra round trip and no HTTP `HEAD`. Measured: Nano + dock SD → `SD 1, internal 38`;
+Edge Pro → `SD 31, internal 45`.
+
+Fall back to the handle rule below in the two cases where the split cannot be trusted: a camera that
+**doesn't echo the counter**, and one that answers **both queries with the same list** (a single-store
+body, where there is nothing to attribute). An empty slice is normal — it means that store held nothing.
+
+**Fallback — the handle's `0x40000000` bit:** set → internal → `storage=1`; clear → SD → `storage=0`.
+It is **not** the manifest list ordinal; a single-store camera's one list is group 0 yet can mount at
+`storage=1`. Handle bases also drive the burst-expand and favourite queries, so fit `base + seq × step`
+per store from the manifest's own handles rather than hardcoding a body's numbers:
+
+| camera | store | handle base / step | `storage=` | source |
+|--------|-------|--------------------|-----------|--------|
+| Osmo Nano | internal | `0x40100000` / `0x40` | `1` | `nano_45.bin` |
+| Osmo Pocket 4 | internal | `0x40100000` / `0x40` | `1` | tester log, 2026-08-08 |
+| Action 6 | internal | `0x4010xxxx` | `1` | |
+| Xtra Edge Pro / Action 5 Pro | SD | `0x00040000` / `0x10` | `0` | |
+| Xtra Edge Pro / Action 5 Pro | internal | `0x40040000` / `0x10` | `1` | `xtra_13.bin` |
+| Pocket 3 | microSD (only store) | `0x00040000` / `0x10` | `0` | `op3_15.bin` (`0x00040010`–`0x000400f0`) |
+
+The Pocket 3 is the one that looks like an outlier and isn't: the rule was never "single store → 1", it
+is *which physical store*. Its one store is a microSD → `SD_CARD` → 0, while the Nano's and Action 6's
+single store is internal → 1. Shipping `storage = list ordinal` instead blanked every Nano thumbnail.
+
+**Two stores in one blob = two lists back to back** — **SD first, then internal** (query order), each
+opening with its own `[u32-LE count][u32-LE size][u32-LE ts]…` header. The leading count covers only the
+*first* list. Proven by dumping the same camera with and without a card: the no-card manifest is
+byte-identical to the mixed manifest's second list.
 - **Naming is irrelevant to the parse.** Because the path/name are read by length, the camera's *Naming Management* custom **Folder** and **File** prefixes decode exactly like stock — `DCIM/DJI_001/DJI_…_D.MP4` (stock), `DCIM/DJI_001/DJI_…_D_OP3.MP4` (Pocket 3), `DCIM/DJI_001_OA5/DJI_…_D_DOA5.MP4` (Action 5, custom folder + file suffix), `…_D_A01.MP4` (a user-typed `A01`) — all the same.
 
 **Read it in Python** (`struct` for the little-endian ints; the buffer is the reassembled `0x00/0x27` payload):
@@ -203,11 +255,11 @@ The `0x00/0x27` tagged record above is the **only** media-list wire format:
 
 | field | type | notes |
 |-------|------|-------|
-| `fileName` | String | e.g. `DJI_…_D.MP4` — our `0d` field |
+| `fileName` | String | e.g. `DJI_…_D.MP4` — the `0d` field |
 | `fileType` | enum `MediaFileType` | photo/video/… → the extension category |
 | `fileSize` | **Long** | the real byte size — **mapped**: `u32-LE @ marker − 12` |
 | `duration` | **Long** | video length (ms) |
-| `frameRate` | enum `VideoFrameRate` | **mapped**: `u8 @ marker − 2`; our fps rational is the same value |
+| `frameRate` | enum `VideoFrameRate` | **mapped**: `u8 @ marker − 2`; the fps rational carries the same value |
 | `resolution` | enum `VideoResolution` | **mapped**: `u8 @ marker − 1` (table below) |
 | `date` | `DateTime` | capture time |
 | `starTag` | enum | favourite / marked flag — **mapped**: `u8 @ [ff\|fe] 19 06 + 9` |
@@ -219,7 +271,21 @@ The `0x00/0x27` tagged record above is the **only** media-list wire format:
 ##### Enum value tables (mined from the DJI app dex — for decoding the record's int fields)
 
 
-**Start/Heart/Favorite** — the byte at `[ff|fe] 19 06` + 9 is DJI's `MediaFileStarTag`: `0 = NONE`, `1 = TAGGED` (starred). Cameras where it works: **Osmo Nano**.
+**Star / Heart / Favorite** — the byte at `[ff|fe] 19 06` + 9 is DJI's `MediaFileStarTag`: `0 = NONE`,
+`1 = TAGGED`. **Read it strictly as `== 1`.** On the Nano it is a real flag — `nano_delete.bin` splits
+**19 unstarred / 26 starred** — but on the Action family that byte is a *length* and never 0 or 1:
+
+| fixture | camera | byte @ +9 |
+|---|---|---|
+| `nano_delete.bin` | Nano | `0` ×19, `1` ×26 — the flag |
+| `nano_45.bin` | Nano | `0` ×45 (captured before anything was favourited) |
+| `xtra_13.bin` | Xtra Edge Pro | `44` ×13 |
+| `xtra_delete.bin` | Xtra Edge Pro | `44` ×41, `48` ×4 |
+| `op3_15.bin` | Pocket 3 | `48` ×15 |
+
+A `!= 0` test therefore marks **every** file on an Action-family body as starred. Writing a favourite
+works on those bodies ([§3](#3-favorite--star-media)); only the read-back offset is unmapped there, so a
+client should show the star on the Nano and treat it as unknown elsewhere rather than trust `+9`.
 
 **frameRate** (`marker−2`) — `VideoFrameRate`:
 
@@ -304,7 +370,8 @@ The `0x00/0x27` tagged record above is the **only** media-list wire format:
 - Payload: `[count:u8][handle:u32-LE × count][count:u32-LE] 00 [count:u32-LE] 01 01 00 00`  — delete 1 file `h`: `01 <h> 01000000 00 01000000 01010000`
 - `handle` = per-file object id from the manifest record head (below); the trailing `00 … 01 01 00 00` is a storage selector, verbatim from the capture.
 - Response: `0x00/0x28` → `0000` = OK  ·  `00d6` = no such handle
-- **Handle** — u32-LE at the record head, located by anchoring on the constant record marker `03 ff 19 06` (at head + 8, so `handle = u32 @ marker − 8`). Nano (361 B records) handles start `0x40104000` step `0x40`; the Action family — Xtra Edge Pro, Action 5/6, Pocket 3 (272 B records) — starts `0x40040000` step `0x10`. (Naming doesn't track the family: only the Xtra rebrand writes `CAM_…`, while genuine Action/Pocket units use `DJI_…`.) Photo records lack the marker → non-deletable (fail-safe).
+- **Handle** — u32-LE at the record head, located by anchoring on the constant record marker `03 ff 19 06` (at head + 8, so `handle = u32 @ marker − 8`). Nano (361 B records) `0x40100000 + seq × 0x40`; the Action family — Xtra Edge Pro, Action 5/6, Pocket 3 (272 B records) — `base + seq × 0x10`, base `0x40040000` internal / `0x00040000` SD. **Fit base and step from the handles the manifest already exposes** rather than hardcoding either: both are per camera *and* per store. Anchoring on the marker is also what makes this safe — searching for a `0x40`-aligned dword finds the right value on a Nano and the wrong one on an Xtra, which the camera rejects with `0xd6`. (Naming doesn't track the family: only the Xtra rebrand writes `CAM_…`, while genuine Action/Pocket units use `DJI_…`.) Photo records lack the marker → non-deletable (fail-safe).
+- ⚠️ **Reject duplicate handles.** A fitted base/step can collide when a manifest mixes stores or a record decodes short. Since the delete is irreversible, treat a handle held by more than one file as non-deletable for *all* of them rather than choosing between them.
 - **Session** — a *write*: it lands inline on the live browse session when the `ackSeq` is correct (see *Datalink transport / sequencing*), else send it in a freshly-registered session (handshake → register → subscribe). Reads answer either way; only writes drop on a wrong `ackSeq`.
 - DUML example (delete handle `0x40104480`): <https://b3yond.d3vl.com/duml/#551f044e020100a0400028018044104001000000000100000001010000a0d1>
 
@@ -329,11 +396,42 @@ The `0x00/0x27` tagged record above is the **only** media-list wire format:
 
 ### Holding playback mode for a whole browse session
 
-Playback (`0x02/0x0c` = `01 01 00 01`) is a **camera-wide mode**, not a per-command flag, and holding it
-is what keeps a camera out of capture — on a Pocket 3 the gimbal parks, which is what a user offloading a
-session wants. Two things have to be right, both learned the hard way on a Nano:
+Playback is a **camera-wide mode**, not a per-command flag. Pagination requires it, some commands
+require it, and while it is held a gimballed body stops filming. The camera **drops the mode about a
+second after it is set unless the app keeps beating**, so entering it is not enough — it has to be held.
 
-**1. Enter once and confirm; never leave mid-session.** From `mimo_nano_delete.pcap`:
+| | frame | when |
+|---|---|---|
+| enter | `0x02/0x0c` payload `01 01 00 01` | once, after registration |
+| beat | `0x00/0x88` sub-cmd `0x17` (14 B, ASCII `APP` at bytes 5-7) | every ~1 s, all session |
+| re-assert | `0x02/0x0c` payload `01 01 00 01` | every ~10 s (optional, idempotent) |
+| leave | `0x02/0x0c` payload `01 01 00 00` | teardown only |
+
+```
+1. handshake + register                              §4–§7
+2. send 0x02/0x0c 01 01 00 01
+3. wait up to ~900 ms for the 0x02/0x0c reply
+      no reply -> resend, up to 3 attempts
+4. loop, ~1 Hz, until teardown:  0x00/0x88 sub-cmd 0x17
+5. every ~10 s:                  0x02/0x0c 01 01 00 01
+6. teardown only:                0x02/0x0c 01 01 00 00
+```
+
+**Wait for the reply at step 3.** The camera does not always answer the first enter — a Pocket 4 took
+two attempts. Mimo also sends the enter twice, 0.6 s apart, on re-entry. Nothing else distinguishes
+"held" from "still recording", so treat an unanswered enter as *not held*.
+
+**The beat is mandatory.** Without a ~1 Hz frame the mode is dropped about a second after it is set; with
+one it holds indefinitely. The distinctive symptom of a missing beat is playback appearing, lasting ~1 s,
+vanishing, and reappearing on the next re-assert.
+
+⚠️ **Do not poll `0x02/0x8E` while holding playback.** It looks like a heartbeat — Mimo sends it ~15 Hz
+over BLE — but it is a keyed parameter GET ([§14](#14-camera-parameters)), and on the datalink it takes
+the camera **out of** playback about a second later. Mimo sends it zero times in a 49 s datalink session.
+
+**Hold the mode; do not toggle it.** Leaving after each operation makes the mode flap and races anything
+that assumes it is held. Mimo enters once and holds for 128 s, leaving only when the user closes the
+album:
 
 ```
  1.10s  APP->CAM  02/0c  01010001      enter
@@ -341,26 +439,21 @@ session wants. Two things have to be right, both learned the hard way on a Nano:
         ... 48 s of browsing, thumbnails and a DELETE — no further 0x02/0x0c at all ...
 ```
 
-and in a longer capture it held 128 s, left only when the user backed out of the album, and on re-entry
-sent the enter **twice 0.6 s apart** — Mimo retries until the camera answers. So: send it, wait for the
-`0x02/0x0c` reply, retry if it doesn't come, and send the leave (`01 01 00 00`) only on teardown. Sending
-leave after each operation makes the mode flap and races anything that assumes it is held.
+**The ~10 s re-assert is optional.** The mode stays on its own; the re-assert only covers being knocked
+out of it by something outside the protocol, such as a button press on the body.
 
-**2. Beat `0x00/0x88` at ~1 Hz, and do NOT send `0x02/0x8E`.**
+**What playback does *not* gate:** status pushes (`0x02/0x80`, `0x02/0x82`) arrive unprompted once
+registered — 493 and 480 times in that 49 s session — so battery and storage need no polling either way.
+Neither does the **first** page of the media list: only pagination needs playback, so a client that shows
+just the newest 45 files can skip this section entirely.
 
-| frame | Mimo, 49 s Nano session | effect |
-|---|---|---|
-| `0x02/0x8E` payload `00011400` | **never sent** | we sent it ~3x/s; it drags the camera OUT of playback about a second after entering |
-| `0x00/0x88` sub-cmd `0x17`, ASCII `APP` @5-7 | announce, twice (t=0.115 s, 0.595 s) | app presence |
-| `0x00/0x88` sub-cmd `0x1a` (`1a 00 00 00 01`, 5 B) | ~1 Hz, all session | the actual keepalive |
+**Confirming the gimbal actually parked:** `0x04/0x05` is position telemetry, pushed continuously while
+the motors run ([§20a](#20a-gimbal-position-telemetry--the-is-it-still-filming-signal)). Frames arriving
+means the gimbal is live; silence means parked.
 
-The camera needs *some* ~1 Hz beat or it drops playback a second after it is set. We send the `0x17`
-announce at 1 Hz, which works and holds the mode for the whole session; Mimo's own beat is the `0x1a`
-sub-command, which is the more faithful thing and is untried. Sending nothing at all is what produces
-"playback appears, 1 s, disappears".
-
-Status does **not** depend on any of this: the camera pushes `0x02/0x80` and `0x02/0x82` on its own once
-registered (493 and 480 times in that 49 s capture), so battery and storage keep updating with no polling.
+**Alternative beat:** Mimo sends the `0x17` announce only twice (t=0.115 s, 0.595 s) and then beats
+`0x00/0x88` sub-cmd **`0x1a`** (`1a 00 00 00 01`, 5 B) at ~1 Hz instead. Untested here; `0x17` at 1 Hz
+holds the mode on every camera tried.
 
 ### Datalink transport / sequencing — the one that makes commands land inline
 
@@ -375,8 +468,8 @@ pagination, highlights) run on **one long-lived session** instead of a fresh reg
 
 For a **command** packet, `ownSeq` (= the udp-hdr seq)
 is the app's **own monotonic `+8` counter**, started at `camera_channel + 8` at registration; it wraps at
-`0xFFFF` and is *independent* of the camera. `ackSeq` is the **last of our own seqs the camera echoed back**
-— it lags `ownSeq` by 8–150, and **stays in our own seq space**. Separately, an ACK packet (`0x04`, seq 0)
+`0xFFFF` and is *independent* of the camera. `ackSeq` is the **last of the app's own seqs the camera echoed
+back** — it lags `ownSeq` by 8–150, and **stays in the app's seq space**. Separately, an ACK packet (`0x04`, seq 0)
 carries `[camSeq][camSeq]` to acknowledge the camera's telemetry stream.
 
 **Do not** put the camera's telemetry seq in a command's `ackSeq`: the camera floods telemetry ~10×
@@ -384,11 +477,26 @@ faster than the app's commands and its seq wraps to a different phase, so an `ac
 from `ownSeq` and the receiver window **silently drops writes** (reads stay lenient). Correct value:
 **`ackSeq = ownSeq − 8`** (the previous command seq).
 
-**Inline commands:** the keep-alive thread owns the socket, so a command that needs a reply needs to be **queued**
-for that thread, see exampke in `DatalinkClient.runCommand`
-/ `runManifestQuery`. Skip the empty-payload transport ACK the camera sends *before* the real reply.
-Playback mode (`0x02/0x0c 01 01 00 01`) is held for the whole browse session (some inline reads/writes need
-it), not entered per-fetch.
+**Inline commands:** the keep-alive thread owns the socket, so a command that needs a reply must be
+**queued** for that thread — see `CameraSession.runCommand` / `runManifestQuery`. Skip the empty-payload
+transport ACK the camera sends *before* the real reply. Playback mode is held for the whole browse
+session (some inline reads/writes need it), not entered per-fetch.
+
+⚠️ **A registered session stops accepting inline WRITES after ~40–70 s, and the two cameras disagree:**
+
+```
+Nano       ok at 45 s, 57 s, 66 s   ·  no reply at 74 s, 94 s, 124 s, 142 s
+Edge Pro   no reply at 51.6 s
+```
+
+**Reads are unaffected** on both — a pagination query at 82 s in the Nano session returned normally. So a
+long browse keeps listing happily and then silently drops the next delete or favourite, with no error.
+The workaround is to track the session's age and **re-register before a write** once it exceeds a
+threshold below the shortest observed failure (40 s covers both cameras above). The underlying cause is
+unidentified, so treat the threshold as empirical.
+
+Note this contradicts [§27](#27-session-open-0x51--required-before-anything-else-mavic-3), where the
+sequence window is *not* enforced — that measurement is from an aircraft. Cameras enforce something here.
 
 ### 4. Handshake  *(not DUML — routing payload)*
 - UDP packet type `0x00`, payload `b88764006400c005140000640000019001c005140000640014006400c00514000064000101040102`
@@ -551,8 +659,8 @@ A GET for a pid that isn't valid in the current state answers a **single error b
 | `13..`  | IANA tz id, ASCII | `45 75 72 6f 70 65 2f 4d 61 64 72 69 64` |
 
 - Response `55 … C0 00 6A 00 01 00 …` — first payload byte `0x00` = **OK**.
-- The camera clock snaps to the sent value and recorded file timestamps follow. Osmosis sends it right
-  after registration on every connect.
+- The camera clock snaps to the sent value and recorded file timestamps follow. Send it right after
+  registration on every connect — a camera that has been off for a while will otherwise stamp files wrong.
 - DUML example (set `Europe/Madrid`): <https://b3yond.d3vl.com/duml/#55270415022828f740006a0100ce2a666a0000000078000d4575726f70652f4d61647269640c0e>
 
 ---
@@ -592,21 +700,33 @@ Note `@17` and `@13` are **mutually exclusive** — each reads 0 in the modes wh
 
 ### 19. SD / storage  *(both stores in one frame)*
 - Cmd Set / ID: `0x02` / `0xDC`  ·  App ← Camera, datalink
-- **Byte 2 = store count.** Two-store bodies are 32 B (**card @6/@10**, **built-in @24/@28**); a
-  single-store body (Pocket 3 = microSD only) is 22 B with just the first block. Decode gate is
-  `size >= 22`, not `>= 32` — the wider gate dropped the Pocket 3 frame and it never reported storage.
+- **Byte 2 = store count**, and byte 5 mirrors it. One `[total][free]` block per store. Measured
+  payload lengths: **22 B single-store**, **40 B two-store** — so gate the decode on `size >= 22` for
+  the first block and `>= 32` for the second, never on an exact length. (A `>= 32` gate on the whole
+  frame dropped the Pocket 3's 22 B body and it never reported storage at all.)
 
 | offset | type | field |
 |--------|------|-------|
-| `@6`  | `u32-LE` | SD **total** MiB (`0` = no card) |
-| `@10` | `u32-LE` | SD **free** MiB |
-| `@24` | `u32-LE` | internal **total** MiB (absent on a 22 B frame → report `0`) |
-| `@28` | `u32-LE` | internal **free** MiB |
+| `@2`  | `u8` | store count (`1` or `2`) |
+| `@6`  | `u32-LE` | first store **total** MiB (`0` = no card) |
+| `@10` | `u32-LE` | first store **free** MiB |
+| `@24` | `u32-LE` | built-in **total** MiB (absent on a 22 B frame → report `0`) |
+| `@28` | `u32-LE` | built-in **free** MiB |
+| `@32`–`@39` | | present on a 40 B body, **unmapped** (one Xtra reads `34216`, `0`) |
 
-- **Card present = SD total > 0**, not a flag byte. Byte 0 is *not* an "SD inserted" bit — it reads
-  `0x11` on a camera with **no** card and `0x00` on cameras **with** one (i.e. backwards).
+- **Card present = first-store total > 0**, not a flag byte. Byte 0 is *not* an "SD inserted" bit: it
+  reads `0x11` on a card-less Xtra and `0x00` on a card-less Nano, so it tracks something else entirely.
+- Verbatim fixtures:
+  ```
+  Nano  22 B  00 12 01 00 00 01 | e7ed0000 09e10000 | …      count=1, 60903/57609 MiB
+  Xtra  40 B  11 12 02 00 00 02 | 00000000 00000000 | … 0101 | 54bf0000 16bf0000 | a8850000 00000000
+                                   ^ no card                    ^ 48980/48918 MiB built-in
+  ```
 - Examples: an Action 6 reads `@6/@10` = 121785/109748 MiB (= its on-screen 118.9/107.2 GB); an Action 5
-  Pro and its Xtra rebadge both report 48980 MiB built-in; a card-less Xtra reads `@6 = 0`.
+  Pro and its Xtra rebadge both report 48980 MiB built-in; a Pocket 4 reports real capacity too.
+- ⚠️ **A Nano can report `0/0`** with a card in and files on internal, in an otherwise well-formed 22 B
+  body — the same shape carries real numbers in other captures. Don't read a zeroed frame as "no
+  storage"; keep the last non-zero values until a later push supersedes them.
 
 ### 20. Battery / power *(also the only place the dock reports in)*
 - Cmd Set / ID: `0x0D` / `0x02`  (34 B, ~1 Hz push)  ·  sender Battery(`0x05`), id `0`
@@ -626,6 +746,14 @@ Note `@17` and `@13` are **mutually exclusive** — each reads 0 in the modes wh
   and only −175 mA — physically docked but not yet drawing charge.
 - **Not reported anywhere:** the dock's *own* charge level, and the dock's SD-card capacity — `0x02/0x80`
   (#18) covers the **active** store only.
+
+### 20a. Gimbal position telemetry — the "is it still filming" signal
+- Cmd Set / ID: `0x04` / `0x05`  ·  App ← Camera, continuous push (~20 Hz) **while the motors run**
+
+The payload layout is unmapped, and for this purpose it doesn't matter: the useful signal is the
+**arrival rate**. A gimballed body streams these while the motors run and stops when the gimbal parks,
+so counting frames tells a client whether the camera is still filming — otherwise only observable by
+looking at it. Use it to verify [playback hold](#holding-playback-mode-for-a-whole-browse-session).
 
 ---
 
@@ -697,7 +825,7 @@ Two consequences:
 ### 25. GetWifiPassword
 - Cmd Set / ID: `0x07` / `0x0e`  ·  App → WiFi(`0x07`), BLE, empty payload
 - Response: `[status:1][PackString passphrase]`
-- Quirks: **give it a beat after GetWifiSsid** (`fff5` is write-without-response; Mimo actually spaces these only a few tens of ms — see [§20](#20-battery--power-also-the-only-place-the-dock-reports-in) — so ~500 ms is just a safe margin). The Nano may not surface a password here — fall back to its saved credentials.
+- Quirks: **give it a beat after GetWifiSsid** (`fff5` is write-without-response; Mimo actually spaces these only a few tens of ms — see [Waking a sleeping camera](#waking-a-sleeping-camera) — so ~500 ms is just a safe margin). The Nano may not surface a password here — fall back to its saved credentials.
 - DUML example: <https://b3yond.d3vl.com/duml/#550d0433020700a040070eb5ef>
 
 ### 26. GetWifiMac
@@ -779,7 +907,7 @@ serial reads out of its beacon correctly once the tag assumption above is droppe
 ```
 datalink: handshake OK on udp/9003
 datalink: session=0xcefb base=0x56f0 channel=0x56f0
-datalink: drone serial 1581FA6QC25BS01CHVJQ (20 chars, tag 0x24)
+datalink: drone serial 1581FA6Q…………CHVJQ (20 chars, tag 0x24)
 datalink: 51/02 open sent, len=40
 datalink: 51-channel replies: 51/13×3            <- beacons only; a Mavic answers 51/08, 51/06, 51/80, 51/82 …
 datalink: drone session-open sent — drone frames/s now 5      <- a Mavic reaches ~268 here
@@ -801,7 +929,7 @@ Other differences worth recording, none of them yet shown to matter:
 - **The handshake reply is 15 bytes, not 9.** Same structure and the same `01` ACK byte, then six extra:
   `01 0f 00 05 05 40 1f`. **Byte-identical across sessions with different session ids**, so it is a fixed
   property of the aircraft or firmware — a version or capability descriptor, not a nonce or a challenge.
-  Meaning unknown; we ignore it and the link still comes up.
+  Meaning unknown; it can be ignored and the link still comes up.
 - **The AP drops ~16 s after joining**, twice, both times just before the list query went out. Plausibly
   downstream of the session never opening, but that is a guess.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Works with the **DJI Osmo Nano**, which isn't supported by the official DJI SDK 
 - Live preview
 - USB-C offload
 - DJI drone offload via QuickTransfer — **working on a Mavic 3**; Neo 2 and Mini 3 in progress
-  ([ROADMAP #14](ROADMAP.md))
+  ([ROADMAP #14 and #18](ROADMAP.md))
 
 ## Supported cameras
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,972 +1,328 @@
 # Osmosis — Roadmap
 
-Planned work, in rough priority order. For the reverse-engineered protocol details referenced
-below, see [docs/01-protocol-map.md](docs/01-protocol-map.md).
+What we want next, and what is already there. Wire-level detail belongs in
+[MEDIA_PROTOCOL.md](MEDIA_PROTOCOL.md) and [docs/01-protocol-map.md](docs/01-protocol-map.md), not here.
 
-**Working today — tester-confirmed on real hardware:** Osmo **Nano**, **Action 5 Pro**, **Action 6**
-and **Pocket 3** (all datalink UDP 9004 + poke), plus the **Xtra Edge Pro** rebrand (UDP 10004, no poke).
-Full pipeline: BLE pair → wake AP → media list → thumbnail grid → LRF preview + download queue →
-resumable high-res `/v2` downloads, across **internal *and* SD** (both stores listed and labelled).
-fps, **byte size**, **resolution**, **duration** and **⭐ starred** all come from the DUML manifest —
-**no MP4 `moov` parse and no HTTP `HEAD`** anywhere in the browse path. Also shipped (v0.5): **delete a file off the camera**
-(long-press → confirm, DUML `0x00/0x28` — #4) and **R-SDK GPS sync** (🛰️ toggle, streams the phone's
-GPS into the camera over BLE — #9, hardware-verified on an Action 5 Pro).
+**Working today, hardware-verified:** Osmo **Nano**, **Action 5 Pro**, **Action 6**, **Pocket 3**,
+**Pocket 4** and **Pocket 4 Pro**, the **Xtra Edge Pro** rebrand, and the **Mavic 3** drone. Full
+pipeline: BLE pair → wake the AP → media list across internal *and* SD → thumbnail grid → proxy
+preview → resumable download, plus delete, favourite and GPS sync. Every grid field (size, fps,
+resolution, duration, ⭐) comes from the manifest — no MP4 `moov` parse, no HTTP `HEAD`.
 
-**Drones work too — Mavic 3, hardware-verified (#14):** BLE pair with the `"DJI FLY"` token → creds →
-AP → a `0x51/0x02` session-open the cameras don't need → the whole library paged to the oldest file,
-with thumbnails, preview and download. The manifest is flat 94-byte **DCF records** rather than
-CompositePack, and media is addressed by packed `file_index` over **`/v1`** rather than by path over
-`/v2` — one `MediaAddressing` seam picks between them. Delete and favourite are camera-only.
-
-**Still open:** the **Action 4** (pairs and hands out BLE creds, but its AP never comes up — an OA4-only
-`0x07/0x39` probe is on the `osmo-action-4-debugging` branch awaiting a test) and the **Osmo 360**
-(parked — never reaches the datalink, and its files are 360-format that needs Mimo to view anyway).
+Item numbers are stable, so an item keeps its number when it moves between the two lists. Nothing else
+in the repo cites them — code and the protocol docs point at [MEDIA_PROTOCOL.md](MEDIA_PROTOCOL.md) or
+at the implementing class, never back here.
 
 ---
 
-## 1. In-preview trimming → trimmed high-res download — ✅ DONE (2026-07-10)
+## Todo
 
-Set in/out points on the paused preview scrubber (`[` / `]` buttons); "Add to Queue (trimmed)"
-queues that window, and Download writes just that slice of the **high-res** clip to the gallery
-(e.g. `DJI_…_0247_D_28-48s.MP4`). Never the LRF, never the whole file. Verified on the Nano.
+### 2. The rest of the Osmo line — Action 4 and Osmo 360
 
-**How it works:** reverse-engineering the Xtra app settled the key question — the camera has **no
-server-side trim**. Its download URL builder (`HttpUrlHelper`) only takes
-`file_index`/`file_subtype`/`file_seg_subindex`, no time range; `clip_start`/`clip_end` live in the
-local segment *editor*, not the download path. So the cut is client-side, but still only pulls the
-window off the camera: `MediaExtractor.setDataSource(<full-res HTTP URL>)` →
-`seekTo(startUs, PREVIOUS_SYNC)` → stream-copy samples into a `MediaMuxer` MediaStore file until
-`endUs`. MediaExtractor honours the process network binding and range-fetches, so only the window's
-bytes (+ `moov`) come off the AP — no whole-file download, no MP4 surgery. Stream copy = no
-re-encode; the start snaps to the nearest keyframe ≤ the in-point (frame-accurate would need
-re-encoding, deliberately out of scope). Code:
+We want every Osmo in the selector to reach the grid. An unrecognised model already falls back to the
+common config (9004 + TCP-7001 poke + WPA2) and is tagged `~experimental`, so it is *attempted*, never
+refused; the datalink retries the alternate config (9004+poke ⇄ 10004/no-poke) and logs which port
+answered. Per-model capabilities live in
+[CameraModel](app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt).
+
+The **Action 2 and 3** sit in the table on the common config but have no data source at all — nobody has
+run one, and they may well belong to #6's older index-based generation rather than here. Two models we
+*have* seen get part-way and stop:
+
+- **Action 4 (`0x14`)** — BLE pair and WiFi creds both succeed, but the AP never comes up (Android sees
+  no SSID). Older BLE generation: MTU 510, no `fff7` characteristic. It has never been sent
+  `0x07/0x39`; an OA4-gated probe waits on branch `osmo-action-4-debugging`.
+- **Osmo 360 (`0x17`)** — pairs and hands out creds, then the phone never finds the `Osmo360` SSID, so
+  it never reaches the datalink. Its AP bring-up differs (it is the only model advertising `fff7`) and
+  may want a 360-specific enable command or 5 GHz.
+
+**Blockers:** the Action 4 needs a tester to run the branch — cheapest first experiment is turning WiFi
+on from the camera's own menu, then tapping it. The 360 needs a PCAPdroid capture of Mimo bringing its
+AP up; deprioritised because 360-format footage needs Mimo to view anyway.
+
+### 6. Older Osmo Action generation (index-based list)
+
+We want browse + download on the Action 1/2/3, which use an older list format keyed by numeric
+`FileIndex` with no path strings ([MEDIA_PROTOCOL §1](MEDIA_PROTOCOL.md#1-get-media-list), "Parsed —
+index-based"). The **list is shipped and hardware-verified** (`decodeIndexList`, fixture
+`action1_7.bin`) — the grid shows the clips. The **download is not**: our `/v1?file_index=` is a
+placeholder, and HTTP `:80` is refused while the datalink is up.
+
+**Branch: `support-osmo-action-1`.** Five commits on top of main: the index decoder ported onto the DCF
+seam with the record layout corrected, the 65-byte stride confirmed on a second camera, and
+`DcfTransferProbe` — which asks the camera outright whether it serves files over the datalink, and
+tests whether `:80` is gated on playback mode. That probe is the experiment that answers this item's
+core question; it has never been run against an Action.
+
+**Blockers:** none any more. Unblocked 2026-08-07 — a decompiled DJI-derived app's media layer turns out
+to be index-based as well, so the download path can be read off rather than guessed at. Two smaller
+fixes ride along: the AP keepalive does not hold an Action's AP (`onLost` ~40 s after the
+list), and the `/v2` storage detect should be skipped for index cameras (it fires two failing HEADs).
+
+### 7. Highlight / moment markers
+
+We want ⚑ chips under the preview scrubber that seek to each side-button mark. Built, verified on the
+Xtra, then **cut from main** — the whole feature lives on branch `highlights`, and the protocol is
+[MEDIA_PROTOCOL §3a](MEDIA_PROTOCOL.md#3a-highlight--moment-marks). Marks are not in the MP4 at all;
+they are pulled from the camera on demand.
+
+**Blockers:** the inline query misses often enough to matter, and a miss falls back to a fresh session —
+which tears the live session down and rebuilds it. On a Nano that cost ~8 s per preview to return `0 []`,
+and two previews in quick succession killed playback mode outright. Revive it when the inline path never
+needs the fallback.
+
+### 8. Camera control and live settings
+
+We want to read the camera's current mode / resolution / fps and control it — start-stop recording, take
+a photo, switch mode. Two halves, and one is done:
+
+- **R-SDK** — solved via #9. `0x1D/0x05`→`0x1D/0x02` streams mode, resolution, fps and recording state;
+  record is `0x1D/0x03` and mode switch `0x1D/0x04`, both already written in `RsdkProtocol`. Only a UI
+  is missing.
+- **Media path** — the command ids are documented with wire examples in
+  [MEDIA_PROTOCOL §Camera control](MEDIA_PROTOCOL.md#camera-control), but they are firmware- and
+  reference-derived and have never been sent to a Nano or Xtra. The status decode is the other gap: we
+  subscribe to the `camcap_*` params and receive the `0x02/0x80` push, but which bytes carry mode /
+  resolution / fps is unmapped. (An old guess — the low nibble of `0x02/0x80` byte 0 — was wrong and
+  was removed.)
+
+**Blockers:** the field decode needs on-device ground truth: change mode/res/fps on the camera and diff
+the frames. The control commands side-effect real hardware, so verify them against a throwaway state.
+
+### 11. Direct USB-C ↔ USB-C media read
+
+We want to offload over a cable, skipping the BLE-pair → wake-AP → WiFi-join dance entirely and running
+at cable speed. Approach: enumerate the camera over Android's USB host API with the phone as host; if it
+presents as MTP, read it through the MediaStore path.
+
+**Blockers:** unknown whether an Osmo presents as MTP / mass-storage to an Android host or only through
+a proprietary DJI USB protocol, and which models do it at all — some default to charge-only and need a
+USB-mode toggle first. Needs a USB-C ↔ USB-C cable, a host-capable phone, and probably a capture of a
+wired Mimo transfer.
+
+### 15. Background downloads with a progress notification
+
+We want the download queue to survive leaving the app, with an ongoing notification: determinate
+progress, current filename, *n of m*, and pause/cancel. Today it is a bare `Thread` started by the
+Activity, so a multi-gigabyte transfer is at the mercy of process death and nothing shows in the shade.
+Resumable range requests already exist in `MediaDownloader`, so a killed transfer should resume rather
+than restart — that is most of the value of doing this.
+
+**Blockers:** the network binding, not the notification. Downloads only work because the process is
+bound to the camera AP (`bindProcessToNetwork`); a service has to own or share that binding and react
+when the AP drops. Android 14+ needs a declared `foregroundServiceType` (`dataSync`) plus
+`POST_NOTIFICATIONS`. And a queue that outlives the foreground session must not keep a drone transfer
+lease alive behind the user's back (#14).
+
+### 16. Per-file shooting details (ISO, shutter, EV…)
+
+We want what Mimo's playback screen shows — what the camera was *set to* when the file was shot. We show
+duration, fps, resolution and size, all manifest fields, and nothing about exposure. Distinct from #8,
+which is the camera's *live* settings. Three sources, cheapest first:
+
+- **Stills — already on the wire.** The EXIF thumbnail path fetches the original's first 64 kB
+  ([EmbeddedJpeg](app/src/main/java/dev/konraditurbe/osmosis/core/EmbeddedJpeg.kt)) and the same `APP1`
+  block carries ISO, exposure time, aperture and focal length. We download and discard them today, so
+  reading them costs one parse and **zero extra requests**. The obvious first increment.
+- **Video — the `djmd` track**, which is protobuf and not encrypted. Needs a range read of the right
+  atom rather than the whole clip.
+- **Drone — `file_subtype` 11 (`PHOTO_METADATA`) / 13 (`JSON`)**, named in the enum recovered from a
+  decompiled DJI-derived app ([MEDIA_PROTOCOL §29](MEDIA_PROTOCOL.md#29-http-media-api-v1--dcf-indexed))
+  but never requested against an aircraft. Subtypes 3–16 were refused on a Neo 2.
+
+### 17. Mavic 3: resolution and fps in the grid
+
+Drone cells show duration and size but no resolution, because the 94-byte DCF record is decoded only as
+far as `+14` ([DcfRecords](app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt): mtime `@0`,
+size `@4`, index `@8`, duration `@12`). The format fields are somewhere in the remaining ~80 bytes.
+
+Do it the way the camera's was done, because that worked: pull a handful of clips shot at deliberately
+different resolutions and frame rates, then diff their records against `ffprobe`.
+
+**Blockers:** needs an aircraft. Two cautions from the camera exercise — **table the enum, never compute
+it** (the camera's codes are sparse and unordered), and **don't assume the camera's table transfers**.
+It may well be the same DJI-wide index, which would make this nearly free, but a wrong shared assumption
+mislabels every clip.
+
+### 18. Drones beyond the Mavic 3
+
+- **Neo 2 (`0x007e`) stalls at the session-open.** It hands over creds with the `DJI FLY` token and
+  handshakes on `udp/9003`, then fails with *no drone serial seen in a beacon*. The `0x51` open has to
+  echo the aircraft's serial, read out of its own `0x51/0x13` beacon
+  ([MEDIA_PROTOCOL §27a](MEDIA_PROTOCOL.md#27a-neo-2--the-same-transport-a-different-unlock)). Two
+  candidates, now instrumented rather than guessed: our parser required a serial of exactly 20 chars
+  (a Mavic 3's length), or the Neo 2 never emits the beacon. A failed open now logs every `0x51` inner
+  command and dumps any `0x13` payload, so the next run tells them apart. Secondary: its AP dropped
+  ~16 s in, 112 ms *before* the list query went out.
+- **Mini 3** — model byte unknown, so it resolves only by the `DRONE_ID_FLOOR` guess. It also enters
+  QuickTransfer differently: no hold-to-confirm at all, **three quick power-button presses** instead,
+  which is why the approval dialog needs its own line for it.
+- **Delete and favourite are camera-only.** Drone records carry no manifest handle, so
+  `CameraFile.deletable` is false and the long-press menu correctly offers neither. Wiring them means
+  finding what a drone deletes *by* — plausibly the packed `file_index` itself.
+- **Untested, would be cheap:** `/v2?storage=N&path=…` on a drone (believed to work, never exercised —
+  everything goes through `/v1`), and `PROXY_MOOV` / `ORIGIN_MOOV` (`file_subtype` 15/16), which serve
+  an MP4's `moov` alone and would replace the range request preview pays to find it.
+- **Any other aircraft.** Ids at or above `0x40` fall back to drone defaults on a documented guess
+  (`CameraModel.DRONE_ID_FLOOR`), which at least gets far enough to be diagnosable.
+
+**Branches: `support-neo2` and `support-mini3`** — the same payload on both, one commit each, because
+the diagnostic an unknown airframe needs is the same one. `DroneFrameCensus` answers what the existing
+logging can't: `0x51 inner cmds seen: NONE` says the aircraft doesn't talk like a Mavic without saying
+what it *does* do. So it censuses every CRC-valid frame by cmdset/cmd (nested included), the raw head
+of each transport packet type, and any payload carrying a **serial-shaped run** (12–24 uppercase
+alphanumerics) — which identifies the frame that carries the serial on *this* airframe even when it
+isn't a `0x51/0x13`. Strictly diagnostic: it never latches a serial or changes what we send, because a
+run that merely looks like a serial isn't one. `support-mini3` also carries the three-press line in the
+approval dialog. `PcapAnalysis` rides along on both for reading a capture with our own decoder.
+
+**Blockers:** hardware. Both branches are instrumentation waiting for one run each — nothing more can
+be deduced from what we have.
+
+---
+
+## Done
+
+### 1. In-preview trimming → trimmed high-res download — 2026-07-10
+
+Set in/out points on the paused preview scrubber (`[` / `]`), and "Add to Queue (trimmed)" writes just
+that slice of the **high-res** clip (`DJI_…_0247_D_28-48s.MP4`) — never the LRF, never the whole file.
+
+The camera has **no server-side trim**, so the cut is client-side but still only pulls the window:
+`MediaExtractor` on the full-res HTTP URL → `seekTo(startUs, PREVIOUS_SYNC)` → stream-copy into a
+`MediaMuxer`. It honours the process network binding and range-fetches, so only the window's bytes
+(+ `moov`) come off the AP. Stream copy means no re-encode, and the start snaps to the nearest keyframe
+≤ the in-point — frame-accurate would need re-encoding, deliberately out of scope.
 [MediaDownloader.downloadTrimmed](app/src/main/java/dev/konraditurbe/osmosis/net/MediaDownloader.kt),
 [MediaPreviewActivity](app/src/main/java/dev/konraditurbe/osmosis/ui/MediaPreviewActivity.kt).
 
-## 2. Support the rest of the Osmo line — ✅ Nano / OA5 / OA6 / Pocket 3 + Xtra confirmed; OA4 + 360 open
+### 3. Retrieve the WiFi password over BLE — 2026-07-14
 
-Built a per-model capability table
-([CameraModel](app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt)) keyed on the BLE model
-byte: datalink port + TCP-poke, WiFi security, and a `verified` flag. The runtime resolves it from
-the scan ([OsmoScanner](app/src/main/java/dev/konraditurbe/osmosis/ble/OsmoScanner.kt) now passes the
-model byte up), so port/poke/WPA come from the **model, not the brand** — the Xtra resolves to
-Action 5 Pro (`0x15`) → 10004 by its model byte, exactly as a DJI-branded Action 5 would.
-Unrecognized models fall back to the common config (9004 + poke + WPA2) so **any DJI Osmo is
-attempted, not refused**; the selector tags unverified models `~experimental`.
+The camera hands out its own SSID and passphrase over BLE once paired, so there is no manual entry:
+after pairing, query `0x07/0x07` then `0x07/0x0e` and feed the results straight into the WiFi join
+([§24](MEDIA_PROTOCOL.md#24-getwifissid), [§25](MEDIA_PROTOCOL.md#25-getwifipassword)).
 
-Status per model:
-- **Verified on hardware:** Osmo **Nano** (`0x19`, 9004+poke), **Action 5 Pro** (`0x15`, 9004+poke),
-  **Action 6** (`0x18`, 9004+poke), **Pocket 3** (`0x20`, 9004+poke), all WPA2 — plus the **Xtra Edge
-  Pro** rebrand (`0x15` by model but **10004, no poke** by its own OUI `EC:9E:EA`).
-- **The Xtra-vs-OA5 port split (settled 2026-07-24):** we once listed "Action 5 Pro" as 10004, but that
-  was **only ever the Xtra Edge Pro** — a covert DJI rebrand sharing model id `0x15` yet with its own OUI.
-  A genuine OA5 Pro is now **tester-confirmed on the DJI-standard 9004 + poke**, so `10004` is
-  Xtra-exclusive and the brand-aware guess was right. Resolution is brand-aware
-  ([CameraModel.resolve](app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt) takes
-  [Brand](app/src/main/java/dev/konraditurbe/osmosis/ble/Brand.kt)), pinned by
-  [CameraModelBrandTest](app/src/test/java/dev/konraditurbe/osmosis/ble/CameraModelBrandTest.kt).
-  Since either guess can be wrong on an untested unit, the datalink now **retries the alternate
-  config** (9004+poke ⇄ 10004/no-poke) when the handshake doesn't land, and logs which port answered
-  — so any test on a real Action 5 Pro / Action 4 / Action 6 self-corrects *and* reports the truth.
-- **✅ Confirmed end-to-end (2026-07-24):** a **genuine DJI Action 5 Pro, Action 6, and Pocket 3** all
-  handshake on `udp/9004 + poke` **and complete the full pipeline** — grid, preview, download — on real
-  hardware across multiple testers. Their `verified` flags are now flipped on
-  ([CameraModel](app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt)), so they drop the
-  `~experimental` tag. That settles the OA5 question (the brand-aware guess was right, **`10004` is
-  Xtra-exclusive**), and the OA6 byte `0x18` is confirmed on hardware (mfr `1800…`). Quirk noted: the
-  **Pocket 3 answers `e0` (reject) to `0x53/0x10`** yet its AP still comes up via the `0x00/0x2b`
-  session — the wake is belt-and-suspenders there.
-- **✅ Media list cracked line-wide (2026-07-24):** the `0x00/0x27` payload is DJI's **CompositePack**
-  TLV (not protobuf, and no reference repo decodes it — they all regex the paths). Rewrote the decoder
-  to read each record's fields by **tag → length → value**
-  ([decodeComposite](app/src/main/java/dev/konraditurbe/osmosis/camera/CameraSession.kt), reverse-engineered
-  from real Nano/Xtra/OA5/OA6/Pocket 3 manifests): media path `1a [len] 00 00 00 01`, thumb `…02`,
-  filename `0d [len]`, delete handle + video size off the `03 ff 19 06` marker. No filename regex at
-  all, so the camera's **Naming Management** custom Folder/File prefixes (`_A01`, `_DOA5`, `_OP3`) and
-  stock names decode identically — that was the whole blocker: OA5/OA6 scraped to zero on the
-  `DJI_001_OA5` folder suffix, the Pocket 3 lost its extension to the `_OP3` name suffix. Decodes
-  **all 45 Nano / 13 Xtra / 2 OA5 / 2 OA6 / 15 Pocket 3** files on real bytes (CompositeManifestTest),
-  and **all five are now confirmed live** (grid + download) on real hardware.
-- **✅ Real media byte size, all cameras (2026-07-24):** it's the `u32-LE` at **`marker − 12`** — pinned
-  by correlating a Mimo capture's records against the **camera's SD card mounted over USB** (85/85 Nano
-  files byte-exact, varying-per-file on the Action family), so the HTTP `HEAD` is gone. The old `head+38`
-  we misread as size is actually the **`.LRF` proxy** size (right-looking on the Nano, a constant on the
-  Action family). RE of the DJI app dex named the fields (`xtra.sdk.keyvalue.value.media.MediaFile`:
-  `fileSize`/`duration`/`frameRate`/`resolution`/…, see [MEDIA_PROTOCOL.md](MEDIA_PROTOCOL.md)).
-- **✅ frameRate, resolution, ⭐ starred — all off the manifest now (2026-07-24):** `frameRate` at
-  `marker−2`, `resolution` at `marker−1` (a **DJI-wide** video-format index — Nano and Xtra emit the
-  same codes; ground-truthed by ffprobe: `95`=2.7K 4:3, `103`=4K 4:3, `10`=1080p, `16`=4K 16:9,
-  `45`=2.7K 16:9, `12`=1080p 4:3), and the `MediaFileStarTag` at `[ff|fe] 19 06 + 9` (Nano videos + photos;
-  **the Action family carries no star flag**, so it degrades to "none"). The star renders in the grid.
-- **✅ duration — the last field, mapped (2026-07-29):** `u16-LE @ marker−4` (whole **seconds**), sitting
-  immediately before the fps/resolution codes: `… [dur:u16][fps:u8][res:u8] 03 ff 19 06 …`. Ground-truthed
-  **16/16 on the Nano and 3/3 on the Xtra**. With it the **MP4 `moov` parse is deleted** — every grid/preview
-  value now comes from the manifest. (Beware: the Nano *mirrors* duration at `marker+26`, the Xtra does not —
-  reading the mirror showed every Xtra clip as `201:21`, which is `"1/"` out of `CAM_001/`. Anchor record
-  windows on the **media-path** fields like the decoder does; filename-anchored windows drift a record.)
-- **✅ Internal + SD, both stores (2026-07-24):** the manifest is **two concatenated per-storage lists**
-  (SD first, then internal), each with its own `[u32 count][u32 size][u32 ts]` header — proven because a
-  no-card manifest is byte-identical to the mixed manifest's *second* list. Storage is now resolved
-  **per list** (was: one probe stamped on all files → half the grid blanked on a camera with a card, hit
-  on an OA6 and an Xtra). The status pill shows **both** capacities from `0x02/0xDC` (card @6/@10,
-  built-in @24/@28), verified against a camera's own on-screen figures. (Byte 0 of that frame is *not* an
-  SD-inserted flag — it reads backwards; presence = capacity > 0.)
-- **⏸️ Osmo 360 (`0x17`) — parked.** BLE pairs and hands out creds, but the phone **never finds the
-  `Osmo360` Wi-Fi SSID** ("searching for device…" → timeout), so it never reaches the datalink; both
-  WPA3 and the new WPA2-fallback fail because there's no AP to attach to — the 360's AP bring-up
-  differs (it's the only model advertising an extra `fff7` GATT characteristic, and may want a
-  360-specific Wi-Fi-enable command or a 5 GHz band). Deprioritized: its footage is 360-format that
-  needs Mimo to view anyway. Cracking it needs a **PCAPdroid capture of Mimo connecting the 360**.
-- **⚠️ Osmo Action 4 (`0x14`) — pairs, but no AP (open).** First OA4 contact (2026-07-24, tester):
-  BLE connect, pairing (`0x07/46`), and WiFi creds over BLE all succeed — but the AP **never comes up**
-  (Android sees no SSID; `ConnectToWiFi` twice drew a `status=19` link-termination), while the OA6 on the
-  same phone/build worked. It's an older BLE generation (MTU 510, no `fff7`). The v0.4 build it was tested
-  on used `ConnectToWiFi(0x07/47)`; it has **never** been sent `0x07/0x39` (dropped for the Nano, but that
-  was Nano-only) — so an OA4-gated `0x07/0x39` wake probe now lives on the **`osmo-action-4-debugging`**
-  branch, awaiting a test. Cheapest first experiment: turn WiFi on from the OA4's own menu, then tap it.
-- **Best-effort default (no data source):** Osmo Action 2 / 3 — Mimo cameras that get the 9004/poke/WPA2
-  default and the `~experimental` tag. Confirming each needs a PCAPdroid capture of Mimo or the unit.
+**Pacing matters:** `fff5` is write-without-response, so the two queries must be ~500 ms apart or the
+second drops, and the first must not race the pairing-approval ACK. Falls back to the saved password or
+a one-time prompt. The passphrase is cached per-MAC and **never logged** — only its length.
 
-Shared, already model-agnostic: pairing (`osmo` token), `/v2` HTTP, `DJI_`/`CAM_` naming, per-list
-storage detect, and the preview/trim/stream flow. **Remaining:** the **Action 4** AP bring-up and the
-**360**'s datalink once it joins — the per-model media-list layouts that used to block OA5/OA6/Pocket 3
-are all solved.
+### 4. Delete a file on the camera — 2026-07-21
 
-**Onboarding UI (2026-07-10):** the app now launches into a **camera selector**
-([SavedCameras](app/src/main/java/dev/konraditurbe/osmosis/core/SavedCameras.kt),
-[CameraListAdapter](app/src/main/java/dev/konraditurbe/osmosis/ui/CameraListAdapter.kt)) — saved
-cameras first (📶 in range / 🚫 out of range, from the live BLE scan), then newly-scanned ones
-tagged **NEW**. Tapping an in-range camera connects → grid; a first-time camera prompts for the WiFi
-password once and is remembered per-MAC (with its model byte, so the Pocket 3's name-fallback
-survives). Long-press → re-enter password / forget. If the camera drops the BLE link while the
-gallery is open (status=19, vs. the benign handoff status=8), the session tears down and returns to
-the selector, which rescans and shows it 🚫.
+Long-press a grid cell → confirm → the file is gone off the card. Verified on the Nano and the Xtra Edge
+Pro. Irreversible, so it sits behind a confirm dialog showing the filename and handle, and is only
+offered for files we resolved a handle for. Wire: `0x00/0x28`
+([MEDIA_PROTOCOL §2](MEDIA_PROTOCOL.md#2-delete-media)); the handle is the `u32-LE` at the head of each
+manifest record. Runs inline on the live session since #12.
 
-## 3. Retrieve the WiFi password over BLE — ✅ DONE (2026-07-14)
+**Two deliberate gaps.** *Photos are non-deletable*: video records carry the `03 ff 19 06` marker we
+anchor the handle on, photo records lay out differently, and widening the search would latch onto the
+*neighbouring* video's marker — a wrong-file irreversible delete, so we fail safe. *Batch delete is
+unsent*: the payload is `[count:u8][handle …]` and `deleteFiles` already builds N, but every capture we
+have is `n=1`, which makes the leading `u8` indistinguishable from a constant. Settle it with one Mimo
+capture of a multi-select delete before writing any batch path.
 
-The camera hands out its own AP SSID + passphrase over BLE once paired — no manual entry needed.
-Cracked by **HCI-snooping the official Xtra app** (`adb bugreport` → `btsnoop_hci.log`), which
-revealed a credential getter in the WiFi cmdset `0x07` that we'd missed:
+### 5. Osmo Nano: dock and power stats — 2026-07-23
 
-| cmd | request | response payload |
-|-----|---------|------------------|
-| `0x07/0x07` | GetWifiSsid | `[status:1][PackString ssid]` |
-| `0x07/0x0e` | **GetWifiPassword** | `[status:1][PackString passphrase]` |
-| `0x07/0x0c` | GetWifiMac  | `[status:1][6-byte MAC]` |
+The status pill shows pack voltage, charge/draw current, and whether the camera is docked and charging,
+decoded from the `0x0d/0x02` battery push
+([MEDIA_PROTOCOL §20](MEDIA_PROTOCOL.md#20-battery--power-also-the-only-place-the-dock-reports-in)).
+`docked` (`@27`) and `charging` (`@32`) are genuinely separate signals — one transition showed attached
+but not yet drawing charge.
 
-Why the earlier `credprobe` sweep missed it: it swept `0x40–0x5F`, but the getters live at the
-**low cmdIds `0x07`/`0x0c`/`0x0e`**. The creds are never pushed unsolicited (nothing during pairing) —
-you have to query them.
+**The dock's own battery % is not exposed by the camera** — closed as *not possible*, not *not done*.
+All three plausible homes were excluded: no second DUML battery device appears when docked, none of the
+53 subscribable params is dock-related, and nothing in the battery frame's 34 bytes tracks it. *Dock
+SD-card space* is a separate, still-open question: `0x02/0x80` reports the active store only.
 
-**Implementation** ([`onPaired`](app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt)): after
-the `0x07/0x45`/`0x46` pairing completes, query `0x07/0x07` then `0x07/0x0e`, parse the
-`[status][PackString]` replies, and feed SSID/password straight into the WiFi join (the native
-`WifiNetworkSpecifier` "join XtraEdgePro-…" dialog). **Pacing matters**: `fff5` is
-write-without-response, so the two queries must be spaced out (~500 ms) or the second drops — and the
-first must not race the pairing-approval ACK. Falls back to the saved password / one-time prompt for
-models that don't answer. The retrieved passphrase is cached per-MAC and **never logged or committed**
-(only its length is logged). Verified on the Xtra Edge Pro / Action 5 Pro: fresh camera →
-approve → creds over BLE → grid, zero manual entry.
+### 9. R-SDK GPS sync — 2026-07-23, verified on an Action 5 Pro
 
-- **Untested:** whether the Nano/360 answer the same `0x07/0x07`/`0x0e` getters (they likely do — we
-  only ever swept the wrong range there too). The fallback keeps them working regardless.
-- **Note:** the R-SDK/accessory family (`Osmo-GPS-Controller-Demo`) uses a different pairing with
-  numeric `verify_data` and is control-only — not a media/credential path.
+The 🛰️ toggle streams the phone's GPS into the camera for geotagging and speed/route overlays, ported
+from DJI's own `Osmo-GPS-Controller-Demo`. It is **BLE-only** — same GATT as the media path, completely
+different frames (SOF `0xAA`, header CRC-16 + whole-frame CRC-32, DJI's `0x3AA3` init), ported in
+`rsdk/RsdkProtocol` and verified byte-for-byte against the demo's own C. `rsdk/GpsService` is a
+foreground service pushing at 1 Hz. Uses **LocationManager, not FusedLocationProvider** — no
+Play-Services dependency, and it uniquely exposes the satellite count the frame carries.
 
-## 4. Delete a specific file on the camera — ✅ DONE (2026-07-21)
+Two field-test bugs, both fixed: we subscribed to `GPS_PROVIDER` alone and seeded from
+`getLastKnownLocation()`, so a stale seed was pushed at 1 Hz for a whole clip (now FUSED + GPS + NETWORK,
+gated on each fix's own timestamp), and the same stale fix made `gpsTime` read an hour behind. Proven
+objectively rather than by eye: the failing clip's `djmd` track decoded to 719 points with exactly one
+distinct position and one distinct timestamp. That track is **protobuf, not encrypted** — read it with
+[`pyosmogps`](https://github.com/francescocaponio/pyosmogps), which doubles as the regression harness.
 
-Long-press a grid cell → confirm → the file is deleted off the camera's card. Verified on **both**
-the Osmo Nano and the Xtra Edge Pro / Action 5 Pro (`status 0x0000`, file gone). Irreversible, so it's
-behind an explicit confirm dialog showing the filename + handle, and only offered for files we could
-resolve a handle for.
+**Branch `rsdk-device-id`** (unmerged) names the camera from the `device_id` its connection request
+carries, and settles which models can do this at all: DJI's R-SDK table covers the Action 4/5 Pro/6 and
+the 360, lists the Nano as unsupported and omits the Pocket 3. It also establishes on hardware that the
+**Xtra rebrand strips R-SDK out** — the Edge Pro connects over GATT and then answers a media-path
+battery push instead of any `0xAA` frame — a second firmware divergence alongside its 10004 port.
 
-**What cracked it:** a live **Mimo↔Nano capture** (PCAPdroid on an Android 10 tablet — the "infeasible"
-note was wrong; it grabs the UDP/9004 datalink DUML in the clear). The RE had it right: delete is
-`SendCompositePack<delete_file_req, MediaFile>` in the **same `0x00` cmdset as the list** — the missing
-byte is **cmdId `0x28`** (list = `0x00/0x26`, delete = `0x00/0x28`).
+### 10. Wake a sleeping camera over BLE — 2026-07-23
 
-- **Wire:** `0x00/0x28`, App→Camera. Payload `[count:u8][handle:u32-LE …][counter:u32] 00 [count:u32]
-  01 01 00 00`; reply `0x00/0x28` = `0000` = OK. The field after the handles is a **per-request
-  counter**, not a second count — it steps 1, 2, 3… across a session (two consecutive deletes in the
-  Mimo capture show `01` then `02` while the other u32 stays `01`). Reading it as a count is what made
-  every delete after the first replay a stale counter.
-- **Handle:** a per-file object id at the **head of each manifest record**, read straight from the list
-  we already fetch. Anchored on the constant record marker `03 ff 19 06` (`handle = u32 at marker-8`) —
-  works for both layouts: Nano (`DJI_`, 361-byte records, handles step `0x40`) and Xtra/Action (`CAM_`,
-  272-byte records, handles step `0x10`). A `0x40`-alignment heuristic worked on the Nano but grabbed a
-  stray dword on the Xtra → `0xd6` "no such handle"; the marker anchor fixed it.
-  ([DatalinkClient.recordStart / deleteFiles](app/src/main/java/dev/konraditurbe/osmosis/camera/CameraSession.kt))
-- **The catch — writes need a fresh session.** The browse keep-alive loop advances our `udpSeq` past the
-  window the camera accepts; reads still get answered but writes are silently dropped, and re-registration
-  itself seems to grant write access. So a delete tears the keep-alive session down and re-opens +
-  registers a fresh datalink (the same path the list fetch uses), issues the delete there, then keeps that
-  session for browse. Cost ≈ **9 s** per delete (the re-handshake; the delete itself is ~0.2 s); the
-  status pill freezes until the next reconnect (the delete session skips status subscriptions).
+Tap a sleeping Nano in the list and it wakes and offloads. It is a **command sequence, not a broadcast**:
+a sleeping camera keeps advertising `ADV_IND`, and Mimo simply connects and drives it with DUML
+([MEDIA_PROTOCOL — waking a sleeping camera](MEDIA_PROTOCOL.md#waking-a-sleeping-camera)).
 
-**Known gaps:** **photos (both cameras) are non-deletable by design.** Video records carry the
-`03 ff 19 06` marker we anchor the handle on; photo records don't have it and lay out differently (the
-handle sits elsewhere, e.g. ~120 B before the name). Widening the search to reach it would instead latch
-onto the *neighbouring video's* marker → a wrong-file, irreversible delete, so we fail-safe to "can't
-delete" instead. (The 400 B window is tuned for this: it reaches a video's own marker at ~195 B but stops
-short of the next record's at ~473 B.) Safe photo support needs a dedicated photo-record anchor verified
-on both families. (Survivors keep their handles after a delete — the grid just drops the one cell, no
-reconnect needed.)
-
-**Batch delete — the payload takes an array, but n>1 has never been sent.** `[count:u8][handle …]` is
-length-prefixed and `deleteFiles(handles: List<Long>)` already builds N, yet all four deletes in the
-Nano *and* Xtra captures are `n=1`, and the UI deletes one file per long-press. With n always 1, both
-the leading `u8` and the trailing `u32` are indistinguishable from constants — the same ambiguity that
-hid the counter above — so sending `02` risks the camera misparsing the handle array rather than
-rejecting it, and a shifted read can synthesise a handle addressing a *different real file*. Settle it
-with **one Mimo capture of a multi-select delete** (`tools/duml_pcap.py --ops` prints `n=`) before
-writing any batch path. No consumer yet regardless: the grid has no multi-select.
-
-## 5. Osmo Nano: dock / power stats — ✅ DONE (2026-07-23)
-
-The status pill now shows the camera's **pack voltage, charge/draw current, and whether it's docked /
-charging** (⚡ next to the percentage, plus a `4.42 V · charging 352 mA` line). Decoded from the
-`0x0d/0x02` battery push, which we were previously reading exactly one byte of.
-
-**The dock's own battery % is NOT exposed by the camera** — that part of this item is closed as
-*not possible*, not as *not done*. All three plausible homes were checked and excluded:
-
-| hypothesis | result |
-|---|---|
-| dock is its own DUML device (a second battery address) | ❌ docked vs undocked shows **only** `type 0x05, id 0` |
-| dock appears in the subscribable params | ❌ all **53** params enumerated; none battery/dock-related |
-| dock charge is a field in the battery frame | ❌ nothing in the 34 bytes tracks it (dock was at 25 %) |
-
-**What the battery frame does carry** — mapped by docking/undocking mid-session and watching which
-bytes moved (far stronger than comparing separate connections, since only the dock state varies):
-
-| offset | field | evidence |
-|--------|-------|----------|
-| `u16 @1` | pack voltage (mV) | 4421 charging ↔ 4297 under load |
-| `i32 @5` | current (mA, signed) | **+372/+352/+272 docked**, **−455/−474 on battery** |
-| `@20` | battery % | (already used) |
-| `u16 @17` | temperature? (45.0/47.0 °C) | plausible, unconfirmed |
-| `@27` | **dock attached** | `64` whenever physically docked |
-| `@32` | **charging** | `1` docked / `0` not, across 3 cycles |
-
-`@27` and `@32` are genuinely different signals: one transition showed `@27=64` (attached) with
-`@32=0` and only −175 mA — docked but not yet drawing charge. Hence `docked` and `charging` are
-separate flags in [CameraStatus](app/src/main/java/dev/konraditurbe/osmosis/core/CameraStatus.kt).
-
-**Still open (was the other half of this item):** *dock SD-card space*. The `0x02/0x80` frame reports
-the **active** store only; selecting/querying the dock's store is untouched and independent of the
-battery work above.
-
-**How the "dock is a separate device" theory died:** a temporary probe logged every DUML device address
-(`(id << 5) | type`, from the sender byte) the first time it spoke, on both transports, across docked
-and undocked connections. No second battery (`type 0x05`, `id != 0`) and no new address ever appeared —
-the dock speaks only *through* the camera's own battery frame. The probe was removed once it had
-answered that; it's in git history if a new accessory ever needs identifying.
-
-## 6. Support the older Osmo Action generation (index-based list) — ⏸️ PARKED (2026-07-15)
-
-The Osmo Action (1) connects but its media list decoded empty. The **list is solved and shipped**;
-the **download is understood in outline but not confirmed on this camera**. Parked here for a clean
-resume. Diagnosis came from an app log + a decrypted **RTOS** log. Below, findings are split by confidence.
-
-### ✅ Proven (hardware-verified and/or cross-confirmed against the camera's RTOS log)
-- **Connection is fine**: BLE pair → WiFi join → datalink handshake all succeed on the Action 1.
-- **The camera sends the list successfully**: RTOS `FileNumToSend: 7, SizeToSend: 463` →
-  `SendList Frag Finish, FileSended: 7`; our app receives exactly those 463 B.
-- **The list is an older index-based format**: reassembled `0x00/0x27` = `[u32 count][u32 total_size]`
-  then fixed **65-byte records** (8 + 7×65 = 463), no path/filename strings. Per record:
-
-  | offset | type | field |
-  |--------|------|-------|
-  | `[0:4]`   | u32-LE   | Unix timestamp |
-  | `[8:12]`  | u32-LE   | **FileIndex** (`0x640251`…`0x640241`) |
-  | `[10:14]` | 2×u16-LE | DCF dir / file number (`100` = `100MEDIA`) |
-  | `[19:23]` | u32-LE   | video UUID (Amba `DjiMovDmx`) |
-  | `[38:42]` | u32-LE   | size-ish (~KB; a photo record reads ~0.6 MB) |
-
-  Cross-confirmed: RTOS `FileIndexSending: 0x640251`(first)/`0x640241`(last) and all 7
-  `current video uuid:0x…` match our decode exactly, in order.
-- **List parser shipped + hardware-verified** (`decodeIndexList`; round-3 grid shows all 7 clips) and
-  unit-test-locked (`DatalinkManifestTest`, fixture `action1_7.bin`). Collect-loop early-exit fixed to
-  count the index header.
-- **HTTP `:80` is refused** on the Action while WiFi + datalink are both up (round-3 `ConnectException`).
-- Paging bug: our `batch==2` `0x40` offset → RTOS `GISInfo Offset out of range` (harmless — page 1
-  already had all 7 — but wrong for index lists).
-
-### ⚠️ Inferred (NOT verified on the Action 1, which is an older/different generation)
-- Older cameras serve media over **static lighttpd/1.4.55 on `:80`** (`libdcam_http_server.so`,
-  `document-root=/mnt/media_rw/emulated`) as **plain DCF paths** (`GET /DCIM/100MEDIA/DJI_XXXX.MP4`) —
-  **not** `/v1?file_index=` or `/v2?storage=` (those are newer-camera API wrappers). Dir-listing is
-  disabled, so filenames can't be browsed.
-- The HTTP server is **state-gated**: enabled by the `duss_proxy` plugin (`http_server_enable=1`,
-  `activate_check=true`); `dji_media_server` handles `enter_playback` / "switch workmode". So `:80`
-  should only listen once the camera is **activated + in playback mode** → the likely cause of the
-  `:80` refusal.
-- ⇒ our round-3 `/v1?file_index=` download is almost certainly wrong; the real flow is probably a
-  workmode-switch DUML command → static DCF `GET`, with the filename built from the record's DCF
-  dir/file.
-- **Core open question:** is the file *transfer* actually HTTP (static, post-workmode) or DUML over the
-  datalink (`DjiTransSrv`, the same service that sent the list)? Both are plausible; unverified.
-
-### ⬜ Remaining (to tackle on resume)
-- **Confirm on the Action 1 itself** — the transport, the workmode/playback trigger, and the exact URL +
-  filename. Cleanest source: **DJI Mimo** (the app that does this). *Blocked* one WiFi capture of Mimo↔Action hands us the command + URL directly.
-- Deep-RE fallback: Ghidra the camera-service binaries for the `enter_playback`/workmode DUML
-  cmd.
-- Rework the index-camera download from the placeholder `/v1?file_index=` to the confirmed mechanism.
-- Fix the AP keepalive (doesn't hold the Action's AP; `onLost` ~40 s after the list).
-- Skip the `/v2` storage auto-detect for index-based cameras (it fires two failing HEADs).
-
-**Resume artifacts:** `reference/osmo-action/` (raw list blob + RTOS log).
-
-## 7. Retrieve highlight / moment markers — ⏸️ PARKED on branch `highlights` (2026-08-06)
-
-DJI "highlight" marks (side-button presses during recording) are **NOT stored in the MP4** — proven
-by an exhaustive teardown of an Action 4 + Xtra clip: not in chapters/tags, not in the `dvtm` protobuf
-metadata track (per-frame telemetry only — orientation quat, ISO, shutter, WB), not in the `dbgi`
-(sensor-debug) track, not in `udta`, not as HEVC SEI. They live **on the camera** and are pulled on
-demand — the Xtra app shows them in its *trim/editor* view.
-
-**The command is `0x02/0xff`** (the SDK's generic `camera_expansion_cmd`; `PullHighLightAction`).
-RE'd empirically from a PCAPdroid capture of the Xtra app opening two marked clips' trim views —
-which matched hardware ground truth byte-for-byte (a 2-mark clip → 4000/7000 ms; a 3-mark clip →
-1000/3000/5000 ms). Runs **inline on the live session** (`DatalinkClient.getHighlights` via `runCommand`,
-no fresh session) now that #12 landed the faithful session.
-
-```
-request  0x02/0xff → Camera(0x01):  40 2f 00 01 0b 00 00 00 [handle:u32-LE] 00 00
-reply    0x02/0xff:  00 · 40 2f 00 01 · [len:u32-LE] · [handle:u32-LE] · [count:u8] · 00 ·
-                     { 00 [startTimeMs:u32-LE] } × count     # count @ byte 13, first mark @ 16, stride 5
-```
-- `handle` = the video's manifest delete-handle (§2). `startTimeMs` = mark start in ms (we show whole
-  marks; a `duration` field wasn't distinguishable in the reply — the marks read as points).
-
-**Was shipped, now parked.** The video preview pulled marks off-UI via the `net/Highlights` bridge and
-showed a row of tappable **⚑ m:ss** chips that seek the player. Verified on the Xtra (`0023` → 4s/7s,
-`0022` → 1s/3s/5s).
-
-**Why it came out of main.** The inline query still missed often enough to matter, and a miss fell back
-to a fresh session — which tears the live session down and rebuilds it. On a Nano that cost ~8 s of churn
-per preview and re-entered playback mode, all to return `0 []`; two previews in quick succession made the
-rebuilds overlap and killed the playback entry outright (see #14). Chapter marks are decorative, the Nano
-never had any, and no camera here uses them enough to justify destabilising every browse session.
-
-The whole feature — `getHighlights`, `net/Highlights`, the ⚑ chips and their layout — lives on the
-`highlights` branch, cut from main at c684998. The protocol itself is documented above and in
-MEDIA_PROTOCOL.md §3a and is not lost. To revive it, the inline path needs to stop needing a
-fresh-session fallback at all.
-
-## 8. Camera control + live settings (mode / resolution / fps, shutter) — 🔬 R-SDK read done via #9; media-path read + all control unimplemented
-
-Turn Osmosis from a pure offloader into a light remote: **read** the camera's current shooting mode
-(video / photo / timelapse), resolution and frame rate, and **control** it — start/stop recording, take a
-photo, switch mode. Two halves:
-
-- **Read — already solved on the R-SDK path (#9).** Over R-SDK, `0x1D/0x05`→`0x1D/0x02` streams mode /
-  resolution / fps / recording status cleanly (parsed into `RsdkProtocol.CameraStatus`). So on an R-SDK
-  camera this is done. The open part is reading the same over the **media path** (WiFi/DUML), for cameras /
-  sessions where we're offloading rather than in GPS mode:
-- **Read (media-path status/settings).** We already subscribe to the camera-capability params over the datalink
-  (`camcap_mode_profile`, `camcap_video_format`, `camcap_fov`, `camcap_iso`, `cam_status`, … — see the
-  subscribe list in [`DatalinkClient`](app/src/main/java/dev/konraditurbe/osmosis/camera/CameraSession.kt)),
-  and the `0x02/0x80` push carries live status. What's missing is the **exact field decode**: which bytes
-  give the current mode / resolution / frame rate. (The old `mode` guess — low nibble of `0x02/0x80`
-  byte 0 — was wrong and was removed; the real values live in the `camcap_*` params or a different offset,
-  and need mapping against ground truth: change mode/res/fps on the camera and diff the frames.)
-- **Write (control).** Two routes. On **R-SDK** (#9) the control commands are documented and clean —
-  record `0x1D/0x03` (`RsdkProtocol.recordControl` already written), mode switch `0x1D/0x04` — so a control
-  UI on top of the R-SDK session is the small remaining piece there. On the **media path**, the command ids
-  (camera cmdset `0x02`: take-photo `0x02/0x01`, start-record `0x02/0x20`, stop-record `0x02/0x21`, set-mode
-  `0x02/0x02`) are now documented with wire examples in
-  [MEDIA_PROTOCOL.md](MEDIA_PROTOCOL.md#camera-control) (from the Pocket 3 + osmo-download repos) — but
-  firmware-/reference-derived, **unverified on the Nano/Xtra**, payloads (mode enum, res/fps selector)
-  unmapped, over the same UDP datalink as the file list.
-
-**Remaining:** map the status fields against on-device ground truth; verify the `0x02` control commands on
-hardware (real-world side-effecting — test on a throwaway state); add a minimal control UI. Reference:
-`reference/osmo-download` (cmd ids) + `reference/Osmo-GPS-Controller-Demo` (`docs/protocol_data_segment.md`,
-camera control).
-
-## 9. R-SDK GPS push — optional Android background service — ✅ DONE, hardware-verified (2026-07-23, shipped in v0.5)
-
-Push the phone's GPS into the camera (geotag / speed + route overlays), porting DJI's own
-**Osmo-GPS-Controller-Demo** (`reference/Osmo-GPS-Controller-Demo`). **Implemented** behind the 🛰️ toggle
-next to "Save logs": turning it on and picking a camera connects over R-SDK and starts a foreground service
-that streams the phone's GPS.
-
-**Confirmed by reading the demo (not inferred):**
-- The R-SDK flow is **BLE-only** — no WiFi AP, no HTTP; a completely separate flow from the media offload.
-  It rides the **same GATT** as the media path (fff0 / notify fff4 / write fff5), just different frames.
-- Different wire protocol: **SOF 0xAA**, header CRC-16 (SOF→SEQ) + whole-frame CRC-32 (SOF→DATA), both with
-  DJI's custom init `0x3AA3`, little-endian. Ported in `rsdk/RsdkProtocol` and **verified byte-for-byte**
-  against frames emitted by the demo's own CRC/framing C (`RsdkProtocolTest`).
-- Pairing is a documented on-screen **approval** (`0x00/0x19`, `verify_mode`/`verify_data`), *not* a crypto
-  wall — replicable, though a different association than our media `0x07/0x45` "osmo" pairing (and the same
-  one the reverted BLE wake broadcast needed).
-- Camera **mode / resolution / fps / recording status** come free over `0x1D/0x05`→`0x1D/0x02` (see #8).
-
-**Built:** `rsdk/RsdkProtocol` (frames + both CRCs + command build/parse), `rsdk/RsdkController` (the
-`connect_logic` handshake → status subscription → GPS push, reusing `GattClient` with `armPairing = false`),
-`rsdk/GpsService` (foreground `location` service: LocationManager GPS + GnssStatus sat-count, 1 Hz push,
-the `Mode - … - Rec - yes/no - gps: healthy/not healthy` notification + a Stop action). Used
-**LocationManager, not FusedLocationProvider** — no Google-Play-Services dependency, and it uniquely exposes
-the satellite count the GPS frame carries.
-
-**✅ Verified on a genuine DJI Osmo Action 5 Pro** (2026-07-23, by an external tester): BLE approval
-handshake, status decode and GPS acceptance all work, and the track lands in the recording.
-
-**Two bugs the field test exposed — both fixed:**
-- *Only the start location was recorded.* We subscribed to `GPS_PROVIDER` alone and seeded `latest` from
-  `getLastKnownLocation()`; when that provider doesn't deliver (backgrounded / cold start / ROM-dependent)
-  the seed never moved and we pushed **one cached fix at 1 Hz for the whole clip**. Now we subscribe to
-  **FUSED (API 31+) + GPS + NETWORK** and gate every push on the fix's *own* timestamp (`freshFix()`, <30 s),
-  so a stale seed can never pose as the live position.
-- *`gpsTime` read ~1 h behind.* Same root cause, not a timezone bug: we stamp the wall-clock from
-  `loc.time`, and that cached fix carried its own hour-old timestamp. (The protocol has **no timezone
-  field** at all — DJI's demo hardcodes `hour + 8` — so the camera stores a bare local wall-clock.)
-
-**Proven objectively, not by eyeballing:** the failing clip's `djmd` track decoded to **719 points with
-exactly 1 distinct position and 1 distinct timestamp** — a frozen feed, since a mere timezone error would
-still advance the clock. That track is **protobuf** (an earlier note here calling it encrypted was wrong);
-read it with [`pyosmogps`](https://github.com/francescocaponio/pyosmogps)
-(`python -m pyosmogps extract -r discard -f 10 clip.mp4 out.gpx`), which doubles as the regression harness:
-a healthy feed shows many distinct positions and advancing timestamps.
-
-**Remaining (optional):** a control UI on top of the live R-SDK session (record `0x1D/0x03`, mode
-`0x1D/0x04` — see #8). The Xtra rebrand probably won't honor R-SDK at all.
-
-## 10. Wake a sleeping camera over BLE — ✅ DONE, verified on the Nano (2026-07-23)
-
-Tap a sleeping Nano in the camera list and it wakes and offloads — no reaching for the power button.
-
-**How it actually works (and how two wrong theories died):**
-- ❌ *DJI's `WKP` wake broadcast.* DJI documents one (`{10, 0xff, 'W','K','P', mac-reversed}`,
-  *Camera Power Mode Settings (001A)*) and we implemented it byte-exactly. It did nothing — an HCI
-  snoop of Mimo shows **Mimo never advertises at all**. That path is for the R-SDK *remote*
-  deep-sleep case, so the implementation (and its `BLUETOOTH_ADVERTISE` permission) was removed;
-  it's recoverable from git history if a remote ever needs it.
-- ❌ *`0x07/0x39` as the AP bring-up.* The camera replies `e0` (reject) to **Mimo too**, so it isn't
-  load-bearing and isn't sent.
-- ✅ **A sleeping Nano keeps advertising `ADV_IND`** under its own name. Mimo simply connects and
-  drives it with DUML. The wake is a *command sequence*, not a broadcast.
-
-**The sequence** (mirrored in `onReady`/`onPaired`), and the bug that hid it — the DUML receiver byte
-is `(id << 5) | type`, and these two commands are **not addressed to the camera**:
-
-| step | cmd | receiver | reply |
-|------|-----|----------|-------|
-| 1 | `0x00/0x2b` `04 00` (before pairing) | **`0xF0`** = type `0x10`, id 7 | — |
-| 2 | `0x07/0x45` SetPairingPIN | `0x07` | `00 01` |
-| 3 | **`0x53/0x10`** `00 00 00 00` | **`0x1C`** = type `0x1C`, id 0 | **`01 00 00 00`** ← wakes it |
-| 4 | `0x00/0x2b` `01 01`, ~1 Hz | `0xF0` | keepalive |
-
-Addressed to Camera (`0x01`) instead — as we first did — every one of them is answered `e0` and the
-camera never wakes. Pinned by
+The bug that hid it: the DUML receiver byte is `(id << 5) | type`, and two of the commands are **not
+addressed to the camera** — `0x00/0x2b` goes to `0xF0` and `0x53/0x10` to `0x1C`. Addressed to Camera
+(`0x01`) every one is answered `e0` and nothing wakes. Pinned by
 [SessionCommandsTest](app/src/test/java/dev/konraditurbe/osmosis/duml/SessionCommandsTest.kt), because
-the failure is *silent*. `0x07/0x47` ConnectToWiFi (never used by Mimo, and correlated with a sleeping
-camera dropping us, `status=19`) is now only a fallback when no creds came over BLE.
+the failure is silent.
 
-**Method note:** cracked by an HCI snoop (`settings put global bluetooth_hci_log 1` → `adb bugreport`
-→ `FS/data/misc/bluetooth/logs/btsnoop_hci.log`) of **Mimo and Osmosis back to back, with the wake
-button-press wall-clock noted**, then diffing the two frame streams. The timestamps are local
-wall-clock (decode with `utcfromtimestamp`). Same technique that cracked #3.
-
-## 11. Direct USB-C ↔ USB-C media read — 🔬 IDEA
-
-Offload over a **USB-C cable** instead of WiFi, for the Osmo models that expose their storage when
-wired to a phone. Would sidestep the whole BLE-pair → wake-AP → WiFi-join dance and run at cable speed —
-attractive for bulk transfers and for cameras/phones where the AP hop is flaky.
-
-- **Open questions:** does the Osmo present as **MTP / USB mass-storage** when plugged into an Android
-  host, or only through a **proprietary DJI USB protocol** (the way Mimo talks to a wired camera)? Which
-  models support it at all? Some Osmos default to "charge only" and need an on-camera "USB mode" toggle
-  (possibly a DUML command) before they enumerate as storage.
-- **Approach:** enumerate the camera over Android's **USB host API** (`UsbManager`) with the phone as
-  host; if it's MTP, read media via the MediaStore/MTP path; if it's a DJI protocol, capture DJI Mimo/the
-  desktop assistant doing a wired transfer and port it. Needs a USB-C ↔ USB-C cable and a host-capable
-  phone.
-- **Why it's worth it:** no AP, no pairing, no password — just plug in and pull, at USB speed.
-
-## 12. Faithful long-lived session (one session, all commands inline) — ✅ DONE (2026-07-30)
+### 12. Faithful long-lived session — 2026-07-30
 
 **The keystone.** Every "fresh registered session" workaround — paging (~15 s/page), delete (~9 s),
-favorite, burst group-expand, the highlight pull (#7) — existed because our session drifted out of the
-camera's write-accept window. The churn was also *harmful*: repeated teardown/re-register destabilized an
-Xtra so its two-storage manifest split collapsed (all files `storage=0` → half the thumbnails 404'd).
-Fixing the session removed every workaround **and** the fragility. All commands now run **inline on one
-long-lived session — instant, no pause, no playback flash**, verified on Nano + Xtra.
-
-**The real bug (one field).** The datalink is a **sliding-window transport**: every packet carries
-`[r8-9 = ack of the peer's seq][r10-11 = my own seq]`, `uhSeq = my own seq`. A command's `r8-9` and
-`r10-11` are **both in the app's own command-seq space** (`r8-9` lags `r10-11` — the last of our seqs the
-camera echoed). We instead put **`lastCamSeq`** in `r8-9`, and `recvAll` refreshes `lastCamSeq` from every
-received packet — i.e. the camera's *telemetry* seq, which floods ~10× faster and wraps to a different
-phase. So our `r8-9` chased the telemetry stream and diverged from our own `r10-11` → the receiver window
-silently dropped **writes** (reads were lenient). A fresh session only "fixed" it by momentarily
-re-aligning the two streams. (My first guess — re-derive `udpSeq` from `lastCamSeq` — was backwards; the
-fix is the opposite: keep `udpSeq` a clean `+8` counter and stop leaking the camera's seq into `r8-9`.)
-
-**The fix (shipped, in order, each on-device-verified):**
-1. **`routingHeader` `r8-9` = our own previous command seq** (`udpSeq − 8`), not `lastCamSeq`. This alone
-   makes writes land on the live session. `udpSeq` stays a `+8` monotonic counter from registration.
-2. **Hold playback** (`0x02/0x0c 01 01 00 01`) for the whole browse session (was entered per-fetch).
-3. **Session-thread command queue** (`runCommand` / `runManifestQuery`): the keep-alive thread owns the
-   socket, so callers queue a command and it's sent + its reply captured from the same recv loop — one
-   in-sequence session. `findReply` skips the empty transport ACK to read the real status reply.
-4. Converted **favorite → burst → delete → pagination → highlights** to inline, fresh-session paths kept
-   as fallbacks (they now rarely fire). Mirroring Mimo's fuller `0x02/0x8e` heartbeat set turned out
-   **not** to be needed — steps 1–2 were enough. See MEDIA_PROTOCOL "Datalink transport / sequencing".
-
----
-
-**Historical note (the problem this solved).** The media list only paginates in **playback mode**
-(`0x02/0x0c` `01 01 00 01`), and older pages used to spin up a **fresh registered session** (~15 s/page)
-because the camera dropped the datalink after ~2 pages and
-any keepalive we insert just drifts our `udpSeq` out of the accept window (see `freshSessionPage`).
-
-DJI Mimo instead **stays in playback mode the entire time the gallery is open**, keeping one long-lived
-session warm with a constant `0x02/0x8e` heartbeat — so *its* pagination is effectively **instantaneous**
-(no re-handshake, no re-enter-playback per page).
-
-- **Idea:** hold the camera in playback for the whole browse session (enter on grid open, leave on
-  `onDestroy`) and keep a single paging session alive, so each scroll-page is one quick query.
-- **Blocker / why we don't already:** it needs the `udpSeq`-window / ~2-page session drop solved — the
-  exact thing that forced fresh-session-per-page. Mimo's constant heartbeat evidently keeps the window
-  aligned; ours (inserted mid-fetch) corrupted the stream, so it needs its own reversing pass.
-- **Trade-off:** persistent playback probably blocks on-camera recording while we're attached and holds
-  the camera's UI in playback; our per-fetch enter/exit is more polite and leaves it usable between loads.
-- **Payoff:** near-instant infinite scroll instead of ~15 s/page — a much nicer feel on 100s-of-clips
-  libraries. See `DatalinkClient.fetchNextPage` and [[pagination-index-first]] in memory.
-
-## 13. Improve previews by byte-range-streaming the LRF — ✅ SCRUB PREVIEW SHIPPED (2026-08-04)
-
-We already stream the low-res `.lrf`/`.lrv` proxy for preview (`MediaPreviewActivity`: `VideoView` +
-native MediaPlayer, which does its own HTTP range requests over the camera's `/v2` endpoint) and it
-plays cleanly. A DJI-Mimo capture shows *how small and range-addressable* the proxy is: Mimo pulls the
-MP4 header (`bytes 0-4095`) + the `moov` atom at the tail, then progressive ~5 MB chunks — a whole
-clip's proxy is only ~17 MB. That cheap random access opens some nice polish on top of what we have:
-
-- ✅ **YouTube-style scrub preview** — a snapshot window floats above the seek bar while you drag,
-  showing the frame under your thumb. `ScrubFrames` decodes straight off the camera with
-  `MediaMetadataRetriever.getScaledFrameAtTime` + `OPTION_CLOSEST_SYNC` (keyframes only — an exact
-  seek would drag every P-frame back to the previous I-frame over the AP), pointed at whichever
-  preview candidate the player actually opened. Two tiers behind one `nearest(ms)`: a 12-cell grid
-  prefetched in the background so the bubble is never empty, plus on-demand frames that jump the
-  queue as the thumb settles (140 ms debounce, stale requests dropped, newest 16 kept). Dragging no
-  longer seeks the player — the clip jumps once, on release, instead of a range fetch per pixel.
-- ✅ **Measured on hardware** (2026-08-04, Nano `.LRF` + Xtra derived `.XRF`, 41+ frames, 0 failures):
-  **~260 ms/frame on the Xtra, ~420 ms on the Nano, and flat regardless of seek distance** — frame
-  @14 s and frame @325 s of the same clip cost the same. That's the range-seek behaviour confirmed
-  empirically: cost is one keyframe fetch + decode, wherever it lives. A 12-cell grid fills in ~6 s.
-  Repeat hits near the same spot get cheaper (~250 ms) — that region is already warm.
-- **Cache the proxy locally on open** — ~17 MB, so one background fetch gives *instant* seeking/scrubbing
-  (no re-buffer on jumps) and feeds the scrub thumbnails with zero extra range round-trips. Still open,
-  and now less pressing: the measured per-frame cost above is low enough that on-demand holds up.
-- **Filmstrip / storyboard strip** under the player — *built and hardware-tested, then replaced* by the
-  scrub preview above (the two answer the same question, and the bubble reads better on a phone). Its
-  cell placement lives on in `ScrubFrames.gridTimes`; the row UI is in git history if we want it back.
-
-Not a bug fix (previews already work) — a UX layer the proxy's small size + range access make cheap.
-
-## 14. Drone offload support — ✅ WORKING on a Mavic 3 (2026-08-01)
-
-**End to end on real hardware:** BLE pair → WiFi creds → AP join → `udp/9003` session-open → **the whole
-library, paged to the oldest file, with thumbnails on every cell** → proxy preview → full-res and
-partial download, plus battery + storage in the status pill.
-
-Verified 2026-08-02 on a Mavic 3: ten pages, 373 files, terminating cleanly on the last page, using ten
-datalink transfers in total — one per page. Two bugs stood between the first 45 files and that: the
-`0x51` session lapsing after ~30 s, and thumbnails leasing a transfer slot each.
-
-**The gate was a session-open handshake on the `0x51` channel.** A drone answers *nothing* until the app
-sends `0x51/0x02` and completes a mutual challenge (`0x51/0x08`, `0x51/0x06`, carrying its serial and an
-app id). Before that it streams ~2 DUML frames/s of empty keepalive; a second after it, ~1200 frames/s
-and every command works. Found by capturing DJI Fly against a **cold** drone — both earlier captures
-began with the session already open, so neither contained the transition. Two traps cost real time:
-`r0-1` is **not** a running ack (it oscillates and only moves when a reply lands, so it can't be used to
-test whether the drone is accepting us), and the **sequence window is not enforced** (DJI Fly runs ~1600
-packets ahead of it). Replaying captured `0x51` frames verbatim still failed until the wrapper's trailing
-counter was re-stamped monotonically — frozen at capture values it ran *backwards*, and the drone
-dropped the open as a replay without answering.
-
-### `/v1` in full
-
-`file_index` is a **packed** field, not a flat number — masking the directory as 16 bits instead of 14
-folds the storage bits in, and every file on internal storage silently disappears from the grid:
-
-```
-bits 31:30 = storage (0 SD, 1 internal eMMC, 2 SSD)
-bits 29:16 = DCF directory, 14 bits (100 → 100MEDIA)
-bits 15:0  = DCF file number (554 → DJI_0554)
-```
-
-`file_subtype` selects the rendition, and the server maps each to a different tree on the card:
-
-| subtype | meaning | path |
-|---:|---|---|
-| 0 | ORG — original | `DCIM/<dir>MEDIA/DJI_<n>` |
-| 1 | THM — thumbnail | `MISC/THM/<dir>/DJI_<n>` |
-| 2 | SCR — screen-res render | `MISC/THM/<dir>/DJI_<n>` |
-| 18 | LRF — low-res proxy video | `DCIM/<dir>MEDIA/DJI_<n>` |
-
-Measured: the subtype-18 proxy is ~7× smaller than the original (38.8 MB vs 273 MB on a 30 s clip) and
-previews at 1280×720. `file_seg_subindex` picks a part of a segmented recording (0 = whole file) and is
-sent on every request — the Mavic 3 tolerates its absence but the parser expects all three parameters.
-The camera-style `/v2?storage=N&path=…` is believed to work on a drone too, but we have never exercised
-it there — everything above goes through `/v1`.
-
-Server is `lighttpd/1.4.55` on TCP 80, no auth. `Last-Modified` on a `/v1` response independently
-confirms the manifest's FAT timestamp decode, to the second.
-
-### Telemetry
-
-The drone wraps its pushes inside `0x51/0x01` tunnel frames, so a top-level scan steps straight over
-them — they need a nested-aware scan. Battery and storage then use the **same field layout as a camera**:
-`0x0D/0x02` @20 percent, @1 pack mV, @5 signed mA; `0x02/0xDC` @6/@10 SD and @24/@28 internal MiB.
-Ground-truthed on a Mavic 3: 26%, 15.18 V, −1.30 A, 238 GB card (149 GB free) + 7.9 GB internal, and
-`0x0D/0x03` carries four cell voltages. Dock/charging bytes are deliberately NOT reused — those are Osmo
-dock semantics and would show a phantom dock indicator on an aircraft.
-
-### Threading
-
-One thread owns the socket. The keep-alive loop is permanently in `recvAll`, so anything else calling it
-gets starved — that broke pagination (a page fetch received *zero bytes*) and stalled thumbnails
-part-way down the grid. Thumbnails and paging queue via `onDroneThread`, and status is decoded inside
-the pump so the pill updates during long transfers rather than only between them.
-
-### Transfers are leased, and must be released
-
-Every `0x00/0x26` media transfer — list *or* thumbnail — holds a slot on the drone until the client
-releases it, and only so many exist. Leak them and the drone stops serving new transfers while telemetry
-keeps streaming, so the link looks perfectly healthy and answers nothing.
-
-The `0x4a` subtypes are a family per transfer kind: `+0` query, `+1` reply, `+2` proceed, `+3` state,
-`+4` release. A media list is `0x00`–`0x04`; a thumbnail is `0x20`–`0x24`. A full exchange, captured
-from the reference app:
-
-```
--> 4a sub=00 seq=0005     query
-<- 4a sub=03 seq=0005     drone raises state, and waits
--> 4a sub=02 seq=0005     app says proceed
-<- 4a sub=01 seq=0005     data
--> 4a sub=04 seq=0005     app releases the slot
-```
-
-We released list transfers but never thumbnail ones, so browsing died a dozen cells in. Two symptoms
-that took a while to connect: paging stopped after ~2 pages, and scrolling *fast* got much further —
-because it outran the thumbnail queue. `seq` is one monotonic counter shared by both transfer kinds;
-the reference app runs it past 30 in a session without stalling.
-
-The failure log used to say `heard (no valid DUML at all)`, which read like a dead link. It wasn't —
-that sink only keeps `pktType 0x03` (the data stream), and the drone was pushing ~850 telemetry packets
-per query throughout. Queries now log received datagrams **by pktType**, so "silent" and "ignoring us"
-can't be confused again.
-
-Separately, and a genuine second bug: the `0x51` data session lapses **~30 s** after it opens unless the
-identity beacon keeps being answered (~2/s — it was answered once, at session open). Measured across
-five sessions, every query at t ≤ 28.5 s worked and every one at t ≥ 28.9 s returned nothing.
-
-### Thumbnails: a still has none on the card
-
-Probed against a Mavic 3 for a photo index: only `file_subtype=0` answers. Every other subtype makes the
-server close the connection with no response — which is how this firmware reports a missing file, not a
-404. A failed lookup returns `HANDLER_ERROR` and the connection dies, which is also why `GET /` returns
-an empty reply. So a still has **no THM, SCR, AIS or LRF** — nothing but the original.
-
-The reference app solves this by pulling *every* thumbnail over the datalink; across three captures it
-never once requests subtype 1 or 2 over HTTP, only subtype 0 (downloads) and 18 (playback). We don't,
-because that path is strictly one-at-a-time and leases a slot per image — a gridful of stills either
-crawls or exhausts the budget.
-
-Instead a still's thumbnail is lifted from the **EXIF block inside the original**: one ranged request
-for the first 64 kB (EXIF's `APP1` is a u16 length, so it cannot be larger), then `EmbeddedJpeg` walks
-the segments to `APP1` and extracts the JPEG within. Measured on a Mavic 3, the embedded thumbnail
-starts 1502 bytes in. Videos keep their THM. Both are plain HTTP and parallelise, and **the datalink now
-carries nothing but the page queries themselves** — one transfer per page, so browsing cannot exhaust
-the slots however far it scrolls.
-
-Deliberately not "find the second `FFD8`": a 14 MP frame's entropy-coded data contains those bytes by
-chance, so the search is confined to `APP1` and stops at `SOS`.
-
-### Reading a capture with our own decoder
-
-`PcapAnalysis` (test sources, skipped unless `OSMOSIS_PCAP` is set) walks a LINKTYPE_RAW pcap, filters
-`udp/9003`, and decodes it with the app's own `DumlTransport.scanFrames`. It prints the pktType mix, the
-command histogram, every `0x4a` subtype with its seq range, and a media timeline with control frames
-dumped verbatim. Every byte-level claim above came out of it, and the frame builders are unit-tested
-against those captured bytes.
-
----
-
-## Historical: how it got here
-
-**⚠️ Everything below this line is a record of the investigation, not a description of the current
-state.** Several sections were written while the feature was still blocked and say so in the present
-tense — "the drone won't serve US", "not yet run against the drone itself". Those were true when
-written and are not true now; they are kept because the eliminations in them are expensive to redo.
-
-DJI drones speak the **same DUML framing** over BLE/WiFi as the Osmo line. The chain was cracked on
-**2026-08-01** — BLE pair (token `"DJI FLY"`) → WiFi creds → AP join → datalink on `udp/9003` →
-**media list** → **download** — from a PCAPdroid capture of DJI Fly ↔ a real **Mavic 3** browsing its
-gallery (`reference/captures/wifi/mavic3_media_browse.pcap`, gitignored), then implemented and
-unit-tested against those bytes before it ever met an aircraft.
-
-### The media API (cracked 2026-08-01)
-
-The drone reuses the camera's DUML query — `0x00/0x26` → `0x00/0x27`, `receiverType 0x01`, the same
-`0x4a` sub-protocol envelope, even the byte-identical `4a04…` follow-up frame — but **answers with a
-completely different body**, and serves the bytes over a different URL.
-
-| | Osmo camera | DJI drone |
-|---|---|---|
-| datalink | `udp/9004` (+tcp-7001 poke) or `10004` | **`udp/9003`, no poke** |
-| list reply | CompositePack TLV, carries **paths** | **flat array of fixed 94-byte records, no filename at all** |
-| media URL | `/v2?storage=N&path=DCIM/…` | **`/v1?file_index=<u32>&file_subtype=0`** |
-| thumbnails | HTTP `.scr`/`.thm` | **over DUML** (`0x4a` subtype `0x20`→`0x21`, chunked JPEG) |
-| playback mode | required to paginate | **not needed** |
-
-**`0x4a` envelope** (both directions): `+0` magic `0x4a`, `+1` subtype (`0x00` list query, `0x01` list
-reply, `0x20` thumb query, `0x21` thumb reply), `+2 u16` length — **low 12 bits are the length, bit
-`0x1000` marks the FINAL chunk** — `+4 u16` seq (echoed), `+6 u32` chunk index. Chunk 0 of a reply adds
-`+10 u32` total file count and `+14 u32` total manifest bytes. That `0x1000` flag is the trap: read the
-length as a plain `u8` and short frames parse fine while every long one silently mis-parses.
-
-**Record — 94 bytes, newest first:** `+0 u32` mtime (unix), `+4 u32` **size in bytes**, `+8 u32`
-**`file_index` = `(folder shl 16) or number`**, `+12 u16` **duration in seconds** (`0` ⇒ still photo).
-Bytes past `+14` are still unmapped (resolution/fps live in there) and are deliberately left `null`
-rather than guessed. There is **no filename on the wire** — `DroneManifest` synthesises DJI's on-card
-convention (`DCIM/100MEDIA/DJI_0554.MP4`) from the index, picking `.MP4`/`.JPG` off the duration.
-
-**Ground truth:** DJI Fly downloaded `file_index` 6554154 and 6554148 in the same capture and the
-server returned `Content-Length` **14168064** and **9494528** — byte-exact matches for the sizes decoded
-out of the manifest, which is what pins the size field and the 94-byte stride. Both were `dur = 0` and
-came back `image/jpeg`, confirming the still-vs-video signal. Pinned by
-[DroneManifestTest](app/src/test/java/dev/konraditurbe/osmosis/drone/DroneManifestTest.kt) against the
-real captured frames (fixture `manifests/mavic3_manifest.txt`).
-
-**Pagination — also solved, and simpler than the camera's.** `cursor = 1` (bytes 10–13 of the query)
-asks for the newest page (45 files); each older page passes **the oldest `file_index` of the page just
-received**, and the drone replays that file as the first record of the next page, so callers dedup by
-index. No fresh session, no playback mode — pages come back to back on the live session. DJI Fly walked
-`1 → 6553910 → 6553865 → 6553821 → 6553777 → 6553768` and stopped when a page returned only the cursor
-file. (The camera's `0x40000001` video-handle cursor is meaningless here — DJI Fly issues it after every
-page and the Mavic answers `count = 0` every time.)
-
-### Hardware attempt (2026-08-01) — the media API is right, the drone won't serve US
-
-Everything up to the media query works against a real Mavic 3: BLE pair with the `"DJI FLY"` token →
-`ALREADY PAIRED` → SSID + passphrase over BLE → AP join at `192.168.2.100` → **`datalink: handshake OK
-on udp/9003`**. Then the drone answers the media query with nothing. Over ~10 runs it sent us ~30 kB
-per session consisting *only* of its own `0x51/0x01` + `0x51/0x13` beacons, and never once replied to a
-command.
-
-**Eliminated by direct byte-level comparison against DJI Fly** (each of these was a real defect, is
-fixed, and did *not* unblock it):
-
-| Suspect | Verdict |
-|---|---|
-| Query payload | **identical** — pinned by `DroneManifestTest` |
-| DUML framing / CRCs | identical (`crc16(frame) == 0` both) |
-| Routing header ack + seq | matched (`ack=channel`, `seq=channel+8`) |
-| Session id / handshake | drone echoes our id and ACKs `01`, same as DJI Fly's |
-| Channel echo (`r0-1`) | drone mirrors our `b887` exactly as it mirrored DJI Fly's `40ef` |
-| Symmetric UDP port | now bind 9003→9003 as DJI Fly does |
-| Camera registration | removed for drones (DJI Fly never sends it) |
-| 29-command WiFi prelude | replayed verbatim |
-| BLE prelude | replayed verbatim (DJI Fly sends it over **BLE**, we had only sent it over WiFi) |
-| 860/s uplink stream (`0x02/0x82`, `0x02/0xdc`, `0x04/0x1c` — 95% of DJI Fly's traffic) | replayed |
-| App identity in `0x07/0x45` | tried DJI Fly's own install UUID |
-
-**Two things worth not re-deriving.** `r0-1` is **not** a running ack — it oscillates
-(`ef40→ef58→ef40→ef60`) and only changes when a reply lands, so it can't be used as an "are we being
-accepted" probe. And the **sequence window is not enforced**: DJI Fly runs ~1600 packets ahead of it.
-Also note the drone replies to *nothing* except `0x00/0x26` — even DJI Fly gets no response to any
-prelude command — so silence during setup is normal and only the manifest is a real signal.
-
-**What that leaves.** Whatever distinguishes us is something the drone knows that isn't in DJI Fly's
-outbound bytes — most likely client authorisation (account binding), given it already withholds
-credentials from any pairing token but `"DJI FLY"`. Seeing it needs a capture of **our own** session,
-which PCAPdroid can't provide: its VPN mode breaks `bindProcessToNetwork`, so an attempted capture
-recorded only DJI Fly's traffic and none of ours. That needs PCAPdroid's root/pcapd mode or `tcpdump`
-on-device.
-
-### Still open
-
-*(Everything the old version of this list called a blocker — the datalink refusing commands, thumbnails
-being unwired, no hardware run — is done. See the top of this item. What's genuinely left:)*
-
-- **Delete and favourite are not implemented on a drone.** `DroneSession` takes the `MediaSession`
-  no-op defaults (`deleteFiles` → `null`, `setFavorite` → `false`), and drone records carry no manifest
-  handle, so `CameraFile.deletable` is false and the long-press menu correctly offers neither. The
-  camera commands exist (`0x00/0x28`, `0x02/0xbf` — the latter does appear in a drone capture), but the
-  handle they address is a camera-manifest field with no equivalent in the 94-byte DCF record. Wiring
-  this means finding what a drone deletes *by* — plausibly the packed `file_index` itself.
-- **`/v2?storage=N&path=…` on a drone** — believed to work, never exercised. Everything drone-side goes
-  through `/v1`, because `DcfAddressing` is chosen for any file with a `fileIndex`.
-- **Record fields past `+14`** are unmapped. The decoder reads mtime `@0`, size `@4`, index `@8` and
-  duration `@12` out of the 94-byte stride and ignores the rest — resolution and fps are in there
-  somewhere (see the new item #18).
-- **`PROXY_MOOV` / `ORIGIN_MOOV`** (`file_subtype` 15/16) serve an MP4's `moov` atom alone and would
-  replace the range request preview currently pays to find it. Untested on any aircraft.
-- **Neo 2 (`0x007e`) — reaches the datalink, then stalls at the `0x51` session-open.** A tester run
-  (2026-08-03) got much further than the earlier scan suggested, and corrects two things previously
-  recorded here: it **does** hand over WiFi credentials (`0x07/0x07` → `DJI-NEO2-168D`, `0x07/0x0e` →
-  a 12-char passphrase), and its **datalink port really is 9003** — the handshake lands and the channel
-  is learned (`session=0x7b46 channel=0x87b8`).
-
-  What fails is one step later: `no drone serial seen in a beacon — cannot open the session`. The
-  session-open has to echo the aircraft's serial back at it, and the serial is read out of its own
-  `0x51/0x13` beacon. Without it there is no session, so the list query draws `rx [NOTHING]` and the
-  grid is empty. This is **not** a `/v1`-vs-`/v2` question — no manifest is reached at all.
-
-  Two candidate causes, now instrumented rather than guessed: the parser required a serial of
-  **exactly 20 characters** (a Mavic 3's length), which would silently reject any other; or the Neo 2
-  never emits the beacon. A failed open now logs every `0x51` inner command seen and dumps a `0x13`
-  payload if one arrived, so the next run distinguishes them.
-
-  Also seen, and secondary until the above is fixed: the **AP dropped after ~16 s**, 112 ms *before*
-  the list query went out — so that query never left the phone regardless.
-- **Any drone that isn't a Mavic 3.** Model ids at or above `0x40` fall back to the drone defaults on a
-  documented guess (`CameraModel.DRONE_ID_FLOOR`); the Mini 3's real model byte is still unknown.
-
-### History (how it got here)
-
-- **Detection already works — via the DJI company id.** A drone advertises DJI's BLE company id
-  `0x08AA` in its mfr data exactly like an Osmo, so the scanner already surfaces it as a `HIT` and reads
-  its model id (the `u16-LE` after the cid). Confirmed on a real **Mavic 3** (named "1001"):
-  `mfr[cid=08aa 7000…]` → model **`0x0070`**. `Brand.of` now treats "carries cid `0x08AA`" ⇒ `DJI`
-  (more robust than OUI/name — a renamed drone still shows it), so it labels `[DJI]` instead of
-  `[UNKNOWN]`.
-- **A drone model-id → name table — partly done.** Both confirmed ids now resolve by name in
-  `BleConstants.MODEL_NAMES` (`0x0070` Mavic 3, `0x007e` Neo 2) and carry `isDrone` in `CameraModel`;
-  anything else at or above `0x40` falls back to drone defaults by the `DRONE_ID_FLOOR` guess. A fuller
-  list is still wanted so unknown aircraft resolve by name rather than by threshold. **Dead end worth
-  recording:** the `LctProductType` enum in a decompiled DJI-derived app is *not* this table — its
-  `0x70` is a Matrice-class aircraft where ours is the Mavic 3, and our Nano's `0x19` is absent
-  entirely. Two schemes that look interchangeable and aren't.
-- **Seen already — DJI Neo 2 (`0x007e`).** In a tester's scan it **pairs over the same BLE DUML**, but
-  returned **no WiFi password** to `0x07/0x0e` — so the credential path looked like it differed on the
-  drone side. **Superseded (2026-08-03):** with the `DJI FLY` token it hands over both SSID and
-  passphrase exactly like a camera. The earlier refusal was the token, not the model. See the Neo 2
-  entry under "Still open" for where it actually stops.
-- **Mavic 3 (`0x0070`) — BLE snoop findings (2026-07-25).** An HCI snoop of **DJI Fly** then Osmosis,
-  back to back (same method as #3/#10), on a real Mavic 3:
-  - **Pairing is identical to a camera.** Both apps use `0x07/0x45 SetPairingPIN` — DJI Fly with token
-    `"DJI FLY"` (+ a UUID identifier), Osmosis with `"osmo"`. The Mavic accepted our pairing after
-    on-screen approval (`0x07/0x45`→`0002`, then `0x07/0x46`→ approved). So our BLE pairing already
-    reaches a drone.
-  - **The Mavic rejects the camera WiFi getters with error `0xe4`:** `0x07/0x07` (SSID) and `0x07/0x0e`
-    (password) each return a bare `e4`, not a `[status][PackString]`. This is *why* offload falls through
-    to the manual prompt (same symptom as the Neo 2, now with the error code).
-  - **DJI Fly never calls those getters.** Its Mavic session is a high-rate `0x51/0x13` push stream
-    (telemetry — every frame just repeats the drone serial), with no `0x07/0x07`/`0x0e`/`0x47`.
-  - **QuickTransfer WiFi does NOT traverse BLE (confirmed 2026-07-25).** A second snoop taken *during an
-    actual QuickTransfer image pull* carried only the same two things — pairing + the `0x51` telemetry
-    heartbeat. No SSID, no password, no WiFi command, no new cmdset; the only ASCII in the whole capture
-    is the drone serial. So DJI Fly brings the QuickTransfer AP up over a **non-BLE channel** — most
-    likely the phone already holds the drone's WiFi creds from first-time **binding** (cached by DJI Fly)
-    and joins the AP directly, or negotiates over WiFi-Direct.
-  - **Creds *do* come over BLE — via the same getters (2026-07-25).** A fresh-bind snoop of DJI Fly
-    (after `pm clear dji.go.v5` + a **2 s drone-battery press** to confirm) shows the drone answering the
-    **same getters Osmosis uses for cameras**: `0x07/0x0c`→ WiFi MAC, `0x07/0x07`→ SSID, `0x07/0x0e`→
-    passphrase, in the `[status][PackString]` format we already decode. It's a **plain WPA2 SoftAP** (the
-    "WiFi-Direct" guess was wrong — DJI Fly `addNetwork()`s it ephemerally).
-  - **But cred release is gated on the pairing IDENTITY, not the button.** Osmosis ran the identical flow
-    — `0x07/0x45` → `0002` approval-required → 2 s button → approved — and still got `no password`. The
-    tell is the **approval code**: DJI Fly's pairing (token **"DJI FLY"**, a per-bind UUID identifier)
-    gets `0x07/0x46` **[01]** and the creds; Osmosis's (token **"osmo"**, our fixed identifier) gets
-    **[02]** and no creds. Cameras give our "osmo" token **[01]** — the *drone* is what discriminates,
-    withholding QuickTransfer creds from a non-official pairing token.
-  - **CONFIRMED (2026-07-25) — the token *is* the gate.** Pairing the Mavic with token **"DJI FLY"**
-    (via Osmosis's existing `--es pin` hook, no rebuild) flipped the approval to `0x07/0x46` **[01]**,
-    and the drone handed over **SSID + passphrase** over BLE (`0x07/0x07`, `0x07/0x0e`) exactly like a
-    camera. Osmosis then **joined the drone AP** (`WiFi link: ip=192.168.2.100`). So BLE creds + WiFi
-    join are solved; the fix is to drone-gate the pairing token to "DJI FLY".
-  - **Remaining — the drone's media API is NOT the camera datalink.** On the drone AP the DUML datalink
-    handshake fails on **both** `udp/9004` and `udp/10004`, so the manifest comes back empty. The drone
-    serves QuickTransfer media some other way (different port / HTTP / MTP-over-WiFi). Direct probing
-    from adb is walled off by Android per-app routing (only the network-bound app reaches
-    `192.168.2.1`). **Next:** PCAPdroid-capture **DJI Fly doing a QuickTransfer browse+download** and
-    read the media API off the wire — same technique that cracked the camera list from the Mimo PCAPs.
-  - **Datalink is up on udp/9003, but the list command differs (2026-07-25).** A QuickTransfer PCAP +
-    a live Osmosis attempt pinned it: the drone uses the **same datalink handshake as a camera on
-    `udp/9003`** (no tcp-7001 poke; TCP-6001 probes RST'd). Osmosis now handshakes fine — but its
-    camera list command `0x00/0x26` gets **no `0x00/0x27` back**: the 43 KB it reads is pure noise —
-    25 `0x51/0x01` telemetry frames (the serial heartbeat) + datalink session heartbeat, no media. So
-    the drone's **media-list command is different** and is the one remaining unknown. **Next:** a
-    cleaner DUML capture of DJI Fly's QuickTransfer *browse* on 9003 — the earlier PCAP had **no
-    inbound** simply because that pairing attempt *failed* (DJI Fly was retrying the handshake into
-    the void), not a capture limitation, so a successful browse should record both directions. Or
-    fuzz the list command now that Osmosis is on the datalink.
-- **✅ The capture landed (2026-08-01).** A PCAPdroid capture of DJI Fly doing a full QuickTransfer
-  browse + two downloads on a real Mavic 3 answered every open question above in one go — the list
-  command was never different, only its *reply* and the media URL were. See "The media API" at the top
-  of this item; the guess that drones "may not use CompositePack" was right.
-- **Scope note (updated):** this started as "see how far the existing DUML stack reaches". It reaches
-  all the way — list, paging and download are the same stack with a different manifest body and a `/v1`
-  URL, so drone support is now a real feature rather than an experiment. Thumbnails turned out **not**
-  to need the DUML plumbing this note once predicted: video cells use the `/v1` THM rendition and stills
-  come out of the original's EXIF, both over plain HTTP.
-
----
-
-## 15. Background downloads with a progress notification — ⬜ TODO
-
-**Where it stands now:** a download queue runs on a bare `Thread` started by the Activity
-([MainActivity](app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt): `Thread { MediaDownloader(…).run(jobs, listener) }`),
-with progress rendered only into the in-app UI. The one foreground service in the manifest is
-`rsdk.GpsService`. So leaving the app puts a multi-gigabyte transfer at the mercy of process death,
-and there is nothing in the shade to show it is alive.
-
-**Wanted:** move the queue into a foreground service with an ongoing notification — determinate
-progress bar, current filename and *n of m*, plus pause/cancel actions.
-
-Worth thinking about before writing it:
-- **The network binding is the hard part, not the notification.** Downloads only work because the
-  process is bound to the camera AP (`bindProcessToNetwork`); a service must own or share that binding,
-  and must react when the AP drops (the BLE link is torn down at handoff, and the camera can sleep
-  mid-queue).
-- Android 14+ wants a declared `foregroundServiceType` — `dataSync` is the fit — and posting the
-  notification needs `POST_NOTIFICATIONS`.
-- Resumable range requests already exist in `MediaDownloader`, so a killed transfer should resume
-  rather than restart; that is most of the value of doing this at all.
-- The drone path holds a **leased transfer slot** per datalink operation (#14). Downloads themselves are
-  plain HTTP and unaffected, but a background queue that outlives the foreground session must not keep
-  a lease alive behind the user's back.
-
-## 16. Per-file shooting details (ISO, shutter, EV…) like Mimo — ⬜ TODO
-
-Mimo's playback screen shows what the camera was *set to* when the file was shot. We show duration, fps,
-resolution and size — all manifest fields — but nothing about exposure.
-
-Note this is **per-file capture metadata**, distinct from #8, which is about the camera's *live* settings.
-
-Three candidate sources, cheapest first:
-- **Stills: already on the wire.** The EXIF thumbnail path fetches the original's first 64 kB
-  ([EmbeddedJpeg.HEAD_BYTES](app/src/main/java/dev/konraditurbe/osmosis/core/EmbeddedJpeg.kt)), and the
-  same `APP1` block carries the standard EXIF tags — ISO, exposure time, aperture, focal length. The
-  bytes are being downloaded and thrown away today; reading them costs one extra parse and **zero extra
-  requests**. This is the obvious first increment.
-- **Video: the `djmd` track.** DJI clips carry an in-file metadata track that is **protobuf, not
-  encrypted** — decodable, and it also carries GPS. Needs a range read of the right atom rather than the
-  whole clip.
-- **Drone: `file_subtype` 11 `PHOTO_METADATA` / 13 `JSON`.** Named in a decompiled DJI-derived app but
-  never requested against an aircraft; the firmware may serve them per index, in which case it is a
-  single small `/v1` fetch. Untested — subtypes 3–16 were refused on a Neo 2.
-
-## 17. Mavic 3: resolution + fps in the preview — ⬜ TODO
-
-Drone cells show duration and size but no resolution, because the 94-byte DCF record is only decoded as
-far as `+14` (mtime `@0`, size `@4`, index `@8`, duration `@12` — see
-[DcfRecords](app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt)). The remaining ~80 bytes are
-unmapped and are the likely home of the format fields.
-
-**Do it the way the camera one was done, because that worked:** the camera's `resolution` byte is a
-DJI-wide format index (`10`=1080p, `16`=4K 16:9, `95`=2.7K 4:3, …) that was pinned by ground-truthing
-manifest bytes against `ffprobe` output on files pulled off the card. Same method here — download a
-handful of Mavic 3 clips at deliberately different resolutions and frame rates, then diff their records.
-
-Two cautions from that exercise:
-- **Table the enum, never compute it.** The camera's codes are sparse and unordered, and there is no
-  reason to expect the drone's to be denser.
-- **Don't assume the camera's table transfers.** It may well be the same DJI-wide index — worth testing
-  first, since it would make this nearly free — but a wrong shared assumption would mislabel every clip.
+favourite, burst expand, highlights — existed because our session drifted out of the camera's
+write-accept window, and the churn was itself harmful: repeated re-registration collapsed an Xtra's
+two-storage split so half the thumbnails 404'd. All commands now run **inline on one session**, verified
+on Nano and Xtra.
+
+One field caused it. The datalink is a sliding-window transport and a command's `r8-9` and `r10-11` are
+**both in the app's own seq space**; we were putting `lastCamSeq` in `r8-9`, so it chased the camera's
+telemetry stream (~10× faster, different phase) and the receiver silently dropped **writes** while reads
+stayed lenient. Fix: `r8-9 = udpSeq − 8`, hold playback for the whole session, and serialise commands on
+the thread that owns the socket. See
+[MEDIA_PROTOCOL — datalink transport / sequencing](MEDIA_PROTOCOL.md#datalink-transport--sequencing--the-one-that-makes-commands-land-inline).
+
+### 13. Scrub preview off the range-seekable proxy — 2026-08-04
+
+A snapshot window floats above the seek bar while you drag, showing the frame under your thumb.
+`ScrubFrames` decodes straight off the camera with `MediaMetadataRetriever.getScaledFrameAtTime` +
+`OPTION_CLOSEST_SYNC` — keyframes only, because an exact seek would drag every P-frame back over the AP.
+Two tiers behind one `nearest(ms)`: a 12-cell grid prefetched in the background so the bubble is never
+empty, plus on-demand frames that jump the queue as the thumb settles. Dragging no longer seeks the
+player; the clip jumps once, on release.
+
+**Measured on hardware** (Nano `.LRF` + Xtra `.XRF`, 41+ frames, 0 failures): ~260 ms/frame on the Xtra,
+~420 ms on the Nano, and **flat regardless of seek distance** — a frame at 14 s and one at 325 s of the
+same clip cost the same. Caching the whole ~17 MB proxy on open is still possible but no longer pressing.
+
+### 14. Drone offload — 2026-08-02, verified on a Mavic 3
+
+BLE pair with the `"DJI FLY"` token → creds → AP → a `0x51/0x02` session-open the cameras don't need →
+the whole library paged to the oldest file, thumbnails on every cell, proxy preview, full and partial
+download, plus battery and storage in the pill. Ten pages, 373 files, terminating cleanly, in ten
+datalink transfers. Protocol in
+[MEDIA_PROTOCOL §27–31](MEDIA_PROTOCOL.md#dji-drone-quicktransfer-media-offload).
+
+The same DUML stack as a camera with two swaps behind one `MediaAddressing` seam: the manifest is flat
+94-byte **DCF records** instead of CompositePack, and media is addressed by packed `file_index` over
+**`/v1`** instead of by path over `/v2`.
+
+Four things that cost real time and are worth not re-deriving:
+
+- **The gate is the `0x51` session-open.** Before it a drone streams ~2 empty keepalive frames/s and
+  answers nothing; a second after it, ~1200 frames/s and every command works. Only a capture against a
+  **cold** drone contains the transition.
+- **Every `0x00/0x26` transfer holds a lease** — list *or* thumbnail — and must be released (`0x4a`
+  subtype `+4`). We released lists but not thumbnails, so browsing died a dozen cells in while telemetry
+  kept streaming and the link looked healthy. Stills now take their thumbnail from the EXIF `APP1` block
+  inside the original (one 64 kB ranged request), so the datalink carries nothing but page queries.
+- **The `0x4a` length is 12 bits plus a `0x1000` FINAL flag.** Read it as a plain length and short
+  frames parse fine while every long one silently mis-parses.
+- **`file_index` is packed**, not a flat number: storage in bits 31:30, a **14-bit** directory in 29:16,
+  file number in 15:0. Masking the directory as 16 bits folds the storage bits in and every internal-
+  storage file vanishes from the grid.
+
+Reading a capture with our own decoder: `PcapAnalysis` (test sources, skipped unless `OSMOSIS_PCAP` is
+set) walks a pcap with the app's own `DumlTransport.scanFrames` and prints the pktType mix, command
+histogram, `0x4a` subtypes and a media timeline. Every byte-level claim above came out of it.

--- a/app/src/main/java/dev/konraditurbe/osmosis/ble/BleConstants.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ble/BleConstants.kt
@@ -39,7 +39,7 @@ object BleConstants {
         // Verified 2026-08-07: OsmoPocket4P-6E55 advertised the new format with product type 218
         // (HG224), which corresponds to classic id 0x22.
         0x0022 to "OsmoPocket4Pro",
-        0x0070 to "Mavic3",   // drone — offload confirmed end-to-end on hardware (ROADMAP #14)
+        0x0070 to "Mavic3",   // drone — offload confirmed end-to-end on hardware (see DroneSession)
         0x007e to "Neo2",     // drone — never offloaded; datalink port unconfirmed
     )
 }

--- a/app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ble/CameraModel.kt
@@ -23,7 +23,8 @@ data class CameraModel(
     val singleSdStorage: Boolean = false,
     // DJI drones (Mavic, Neo, …) speak the same BLE DUML but differ downstream: their WiFi creds only
     // unlock for the official pairing token ("DJI FLY", not "osmo"), pairing is confirmed by a ~2 s
-    // power-button press, and their media API is NOT the camera datalink (see ROADMAP #14).
+    // power-button press, and their media API is NOT the camera datalink (see DroneSession, and
+    // MEDIA_PROTOCOL.md § "DJI Drone QuickTransfer media offload").
     val isDrone: Boolean = false,
 ) {
     /** The SetPairingPIN token this device expects: a drone only releases WiFi creds to "DJI FLY". */
@@ -79,7 +80,7 @@ data class CameraModel(
             // this flag governs really is confirmed, even though no download has yet finished.
             // It advertises the new format (product type 218 / HG224), not a classic model byte.
             0x0022 to CameraModel("Osmo Pocket 4 Pro", verified = true),
-            // Drones (see ROADMAP #14). The datalink is the SAME handshake as a camera but on
+            // Drones (MEDIA_PROTOCOL.md §27). The datalink is the SAME handshake as a camera but on
             // **udp/9003** with NO tcp-7001 poke — plus a `0x51/0x02` session-open the cameras don't
             // need, before which the aircraft answers nothing at all.
             //

--- a/app/src/main/java/dev/konraditurbe/osmosis/camera/CameraSession.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/camera/CameraSession.kt
@@ -673,7 +673,7 @@ class CameraSession(
      * Delete files by their manifest [handles] (DUML **0x00/0x28** — the file-management cmdset, same
      * one the list `0x00/0x26` lives in; reverse-engineered from a Mimo↔Nano pcap). Returns the reply
      * status word (**0x0000 = OK**), or null on failure/timeout. **Irreversible on the SD card** — the
-     * caller must confirm intent and pass only handles it means to destroy. See ROADMAP #4.
+     * caller must confirm intent and pass only handles it means to destroy. MEDIA_PROTOCOL.md §2.
      *
      * Runs in a **fresh registered session**: the browse keep-alive loop advances our `udpSeq` past
      * the window the camera will accept, and while reads (the list) still get answered, writes get

--- a/app/src/main/java/dev/konraditurbe/osmosis/core/CameraFile.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/core/CameraFile.kt
@@ -35,7 +35,7 @@ data class CameraFile(
     // DCF-INDEXED DEVICES ONLY (0 on a path-based camera). Drones — and the Osmo Action 1 — address
     // media by a packed numeric index instead of a path, served at `/v1?file_index=N` rather than
     // `/v2?…&path=…`. The [path] above is synthesised from this index for display/naming only — it is
-    // NOT a URL these devices answer. See [DcfIndex], [DcfUrls] and ROADMAP #14.
+    // NOT a URL these devices answer. See [DcfIndex], [DcfUrls] and MEDIA_PROTOCOL.md §29.
     val fileIndex: Long = 0L,
     // Modification time, unix seconds — drones put it straight in the manifest record, where cameras
     // encode it in the filename ([timestamp]). 0 = unknown.

--- a/app/src/main/java/dev/konraditurbe/osmosis/core/CameraStatus.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/core/CameraStatus.kt
@@ -4,7 +4,7 @@ package dev.konraditurbe.osmosis.core
  * Live camera status decoded off the DUML datalink (battery, power, storage, firmware).
  *
  * The power fields come from the `0x0d/0x02` battery push, mapped by docking/undocking a Nano
- * mid-session and watching which bytes moved (ROADMAP #5). Note the dock's *own* charge level is not
+ * mid-session and watching which bytes moved (MEDIA_PROTOCOL.md §20). Note the dock's *own* charge is not
  * reported anywhere in the protocol — only the camera's, plus whether the dock is attached/charging.
  */
 data class CameraStatus(

--- a/app/src/main/java/dev/konraditurbe/osmosis/core/MediaAddressing.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/core/MediaAddressing.kt
@@ -9,7 +9,7 @@ import dev.konraditurbe.osmosis.dcf.DcfAddressing
  *
  * | | path-based camera | DCF-indexed device |
  * |---|---|---|
- * | who | Nano, Osmo Action 5 Pro / Xtra, the 360 | Mavic 3 family; Osmo Action 1 (ROADMAP #6) |
+ * | who | Nano, Osmo Action 5 Pro / Xtra, the 360 | Mavic 3 family; Osmo Action 1 ([DcfRecords]) |
  * | endpoint | `/v2?storage=N&path=…` | `/v1?file_index=…&file_subtype=…` |
  * | proxy | a sidecar file (`.LRF`/`.XRF`) at its own path | a **subtype** of the same index |
  * | impl | [PathAddressing] | [DcfAddressing] |

--- a/app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfIndex.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfIndex.kt
@@ -10,7 +10,8 @@ package dev.konraditurbe.osmosis.dcf
  *
  * This is **not drone-specific**. Two very different devices address media this way:
  *  - **drones** (Mavic 3 family) — 94-byte manifest records, see [DcfRecords.decodeDrone];
- *  - the **Osmo Action 1** — 65-byte index records over the same `/v1` endpoint (ROADMAP #6).
+ *  - the **Osmo Action 1** — 65-byte index records over the same `/v1` endpoint, see
+ *    [DcfRecords.ACTION1_STRIDE] and MEDIA_PROTOCOL.md §1 ("Parsed — index-based").
  *
  * Everything else in the app addresses media by *path* over `/v2?storage=N&path=…` instead. Keeping the
  * two schemes in separate packages is the point: a path-based camera never touches this file.

--- a/app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt
@@ -54,7 +54,8 @@ object DcfRecords {
     /**
      * Osmo Action 1 record stride — its list is `[u32 count][u32 totalBytes]` then fixed 65-byte records
      * carrying **unix** seconds at `+0` (not FAT) and the packed index at `+8`. Decoder lands with the
-     * `add-osmo-action-support` branch, which has the fixture to test it against; see ROADMAP #6.
+     * `support-osmo-action-1` branch, which has the fixture to test it against. Layout:
+     * MEDIA_PROTOCOL.md §1 ("Parsed — index-based").
      */
     const val ACTION1_STRIDE = 65
 

--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneManifest.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneManifest.kt
@@ -7,7 +7,7 @@ import dev.konraditurbe.osmosis.dcf.DcfRecords
  * The DJI **drone** wire format for media listing — a different payload inside the *same*
  * `0x00/0x26` → `0x00/0x27` DUML exchange the Osmo cameras use. Reverse-engineered from a PCAPdroid
  * capture of **DJI Fly ↔ a real Mavic 3** browsing its gallery over QuickTransfer WiFi (2026-08-01);
- * see ROADMAP #14.
+ * see MEDIA_PROTOCOL.md §28.
  *
  * **What's the same as a camera:** the DUML command pair (`0x00/0x26` query, `0x00/0x27` reply,
  * `receiverType = 0x01`), the datalink transport, and the `0x4a` sub-protocol envelope — the drone

--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneSession.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneSession.kt
@@ -6,8 +6,8 @@ import dev.konraditurbe.osmosis.duml.DjiMessage
 import dev.konraditurbe.osmosis.net.DumlSession
 
 /**
- * A media session with a DJI **drone** (Mavic 3 family) over QuickTransfer WiFi. See ROADMAP #14 and
- * MEDIA_PROTOCOL.md § "DJI Drone QuickTransfer media offload".
+ * A media session with a DJI **drone** (Mavic 3 family) over QuickTransfer WiFi. See
+ * MEDIA_PROTOCOL.md § "DJI Drone QuickTransfer media offload" (§27–31).
  *
  * Nothing below the [DumlSession] handshake is shared with a camera:
  *
@@ -41,7 +41,7 @@ class DroneSession(
     private val droneSeen = HashSet<Long>()
     private var querySeq = 0x0C
 
-    // ---- paging diagnostics (ROADMAP #14, "paging stops after page 2") -----------------------------
+    // ---- paging diagnostics (the "paging stops after page 2" bug) ----------------------------------
     // Every datagram seen during a query, counted by transport pktType. This is the field the old
     // failure log could NOT show: its sink keeps only pktType 0x03 (the data stream), so "no valid DUML
     // at all" was equally consistent with a silent drone and a chatty one that simply ignored the query.
@@ -495,7 +495,7 @@ class DroneSession(
      * four instrumented sessions, every media query at t ≤ 28.5 s succeeded and every one at t ≥ 28.9 s
      * came back empty — while the drone was still pushing ~850 telemetry packets per query. The uplink
      * stream keeps the *link* alive, so nothing looks wrong; it is the `0x51` data session underneath
-     * that lapses. See ROADMAP #14.
+     * that lapses. See MEDIA_PROTOCOL.md §27.
      */
     @Volatile private var beaconOn = false
     private var lastBeaconMs = 0L

--- a/app/src/main/java/dev/konraditurbe/osmosis/net/DumlSession.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/net/DumlSession.kt
@@ -227,10 +227,12 @@ abstract class DumlSession(
                 ); return true
             }
             set == 0x02 && id == 0xDC && p.size >= 22 -> {
-                // One [total][free] u32-LE MiB block PER STORE (byte 2 = store count): the first at
-                // @6/@10, the built-in at @24/@28. Two-store bodies send 32 B (SD @6 + built-in @24);
-                // a **single-store body (Pocket 3 = microSD only) sends 22 B** with just the first
-                // block, so read the built-in only when it's actually there. Ground-truthed: an
+                // One [total][free] u32-LE MiB block PER STORE (byte 2 = store count, mirrored at
+                // byte 5): the first at @6/@10, the built-in at @24/@28. Measured payload lengths are
+                // 22 B single-store and 40 B two-store (xtra_13.bin) — @32-39 of the 40 B body is
+                // unmapped. The >= 32 test below is a "is the second block present" gate, NOT the
+                // frame length; a **single-store body (Pocket 3 = microSD only) sends 22 B** with just
+                // the first block, so read the built-in only when it's actually there. Ground-truthed: an
                 // Action 6's @6/@10 (121785/109748 MiB) matched its on-screen 118.9/107.2 GB; the
                 // Action 5 Pro + Xtra rebadge report an identical 48980 MiB built-in; a card-less
                 // Xtra reports @6 = 0. Byte 0 is *not* an inserted flag (0x11 no card / 0x00 with) —

--- a/app/src/main/java/dev/konraditurbe/osmosis/net/DumlSession.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/net/DumlSession.kt
@@ -277,7 +277,7 @@ abstract class DumlSession(
                 // type 0x05 id 0), so the dock signal lives in this frame: u16@1 = pack mV,
                 // i32@5 = current mA (signed, -ve = discharging), @20 = percent, @27 = dock
                 // attached, @32 = taking charge. Confirmed over six live dock/undock transitions
-                // (ROADMAP #5). Logged on change only — a state line, not a 1 Hz stream.
+                // (MEDIA_PROTOCOL.md §20). Logged on change only — a state line, not a 1 Hz stream.
                 if (p.size >= 34) {
                     val mv = (p[1].toInt() and 0xFF) or ((p[2].toInt() and 0xFF) shl 8)
                     val cur = ((p[5].toInt() and 0xFF) or ((p[6].toInt() and 0xFF) shl 8) or

--- a/app/src/main/java/dev/konraditurbe/osmosis/net/DumlTransport.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/net/DumlTransport.kt
@@ -265,7 +265,8 @@ class DumlTransport(
      * 1. r0-1 once held `camChannel` — the *camera's* telemetry seq, refreshed by every received packet.
      *    Telemetry runs ~10× faster than our commands and wraps to a different phase, so r0-1 drifted far
      *    from r2-3 and the receive window dropped our writes. That single divergence is what forced a
-     *    fresh registered session for every delete/favorite/page/burst (ROADMAP #12).
+     *    fresh registered session for every delete/favorite/page/burst. See MEDIA_PROTOCOL.md
+     *    § "Datalink transport / sequencing".
      * 2. A later revision set the *drone* ack to `camChannel`, on the theory that a drone echoes our seq
      *    back in r0-1. It does not — it repeats the handshake channel forever, so the ack froze at
      *    `0x87b8` while our seq ran away with the uplink stream: measured 564 packets stale against DJI

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
@@ -653,7 +653,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         // advertises. The sleeping camera keeps advertising ADV_IND itself, and Mimo simply connects
         // and drives it with DUML (0x00/0x2b -> pair -> 0x53/0x10). That's the sequence we follow in
         // onReady/onPaired. (DJI also documents a 'WKP' wake *broadcast*; an HCI snoop proved Mimo
-        // never advertises, so it isn't used here — see ROADMAP #10.)
+        // never advertises, so it isn't used here — see MEDIA_PROTOCOL.md § "Waking a sleeping camera".)
         val gc = GattClient(this, this)
         gattClient = gc
         gc.connect(device)
@@ -853,7 +853,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         // bindProcessToNetwork pins our sockets to the AP network and bypasses that VPN — so a VPN-mode
         // capture sees none of our traffic (and on this tablet the bind then fails outright, killing the
         // datalink). Joining the AP normally makes it the DEFAULT route, so our traffic goes through the
-        // VPN, gets captured, and still reaches the drone. See ROADMAP #14.
+        // VPN, gets captured, and still reaches the drone.
         if (noJoin) {
             logLine("OFFLOAD: --ez nojoin — skipping the WiFi join, using the current default network")
             main.postDelayed({ startDatalink() }, 1500)
@@ -961,7 +961,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
                     fun open(m: CameraModel): Pair<MediaSession, List<CameraFile>> {
                         logLine("=== media list [${m.name}] via udp/${m.datalinkPort} (poke=${m.tcpPoke}) ===")
                         // A drone speaks a different protocol end to end — the 0x51 session-open gate,
-                        // flat DCF records instead of CompositePack, /v1 instead of /v2 (ROADMAP #14).
+                        // flat DCF records instead of CompositePack, /v1 instead of /v2 (DroneSession).
                         // This is the only place in the app that decides which of the two it is.
                         val c: MediaSession =
                             if (m.isDrone) DroneSession(::logLine, m.datalinkPort, bleDroneSerial)

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/StatusPillView.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/StatusPillView.kt
@@ -97,7 +97,7 @@ class StatusPillView @JvmOverloads constructor(
     /**
      * Power line from the `0x0d/0x02` battery frame: pack voltage plus charge/draw current, and
      * whether the dock is attached. The dock's *own* charge level isn't reported by the camera at all
-     * (ROADMAP #5), so we show the camera's power state rather than inventing a dock percentage.
+     * (MEDIA_PROTOCOL.md §20), so we show the camera's power state rather than invent a dock percentage.
      */
     private fun powerLabel(s: CameraStatus): String {
         val volts = "%.2f V".format(s.batteryMilliVolts / 1000f)

--- a/app/src/test/java/dev/konraditurbe/osmosis/dcf/DcfIndexTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/dcf/DcfIndexTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 
 /**
  * The DCF addressing scheme on its own, independent of any device's wire format — the layer shared by
- * the drones and (per ROADMAP #6) the Osmo Action 1.
+ * the drones and the Osmo Action 1 (MEDIA_PROTOCOL.md §1, "Parsed — index-based").
  *
  * These assertions were previously reachable only through a Mavic 3 manifest fixture. Pinning them
  * directly is what lets a second record layout be added without re-deriving the packing rules.

--- a/app/src/test/java/dev/konraditurbe/osmosis/net/DumlTransportTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/net/DumlTransportTest.kt
@@ -11,8 +11,8 @@ import org.junit.Test
  * The datalink's wire framing.
  *
  * Worth having specifically because the two worst outages in this code's history were both **wrong
- * values in the 12-byte routing header** — leaking the peer's telemetry seq into our ack (ROADMAP #12,
- * which forced a fresh registered session for every delete/favourite/page/burst), and then freezing the
+ * values in the 12-byte routing header** — leaking the peer's telemetry seq into our ack (which forced a
+ * fresh registered session for every delete/favourite/page/burst), and then freezing the
  * drone's ack at the handshake channel (a healthy-looking session that answered no command at all).
  * Both were silent in the same asymmetric way: reads and keepalive kept flowing while writes were
  * dropped by the receive window. Neither was catchable by a test while these builders were private and
@@ -51,7 +51,7 @@ class DumlTransportTest {
 
     @Test
     fun `the ack is our own previous seq, never the peer's channel`() {
-        // ROADMAP #12: r0-1 once held the camera's telemetry seq, which runs ~10x faster than our
+        // r0-1 once held the camera's telemetry seq, which runs ~10x faster than our
         // commands and wraps to a different phase, so it drifted out of the receive window.
         val rt = DumlTransport.routingHeader(seq = 0x1570, cmdCounter = 3, drone = false)
         assertEquals(12, rt.size)

--- a/docs/01-protocol-map.md
+++ b/docs/01-protocol-map.md
@@ -176,9 +176,10 @@ HEAD supported (Content-Length) ; Range supported (206 partial)
 - **Thumbnails:** `MISC/THM/.../<name>.scr` (same storage id), served by `/v2`; the `.scr` decodes as a
   JPEG (`BitmapFactory` renders it directly).
 - Both verified cameras are `/v2` servers. The `/v1?file_index=…&file_subtype=…&file_seg_subindex=…`
-  form exists in DJI apps for other/older models; on the Xtra it is connection-reset. See ROADMAP #6
-  for the older Osmo Action generation (different, index-based list — parked, code on the
-  `add-osmo-action-support` branch).
+  form exists in DJI apps for other/older models; on the Xtra it is connection-reset. The older Osmo
+  Action generation uses that endpoint with a different, index-based list — see
+  [MEDIA_PROTOCOL §1](../MEDIA_PROTOCOL.md#1-get-media-list) ("Parsed — index-based"); code is parked
+  on the `support-osmo-action-1` branch.
 
 ---
 
@@ -354,7 +355,8 @@ bits 29:16 = DCF directory, 14 bits (100 -> 100MEDIA)
 bits 15:0  = DCF file number (554 -> DJI_0554)
 ```
 
-Full detail, ground truth and open questions: **[ROADMAP #14](../ROADMAP.md)**; implementation in
+Full detail and ground truth:
+**[MEDIA_PROTOCOL §27–31](../MEDIA_PROTOCOL.md#dji-drone-quicktransfer-media-offload)**; implementation in
 [DcfRecords.kt](../app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt), pinned by
 [DroneManifestTest](../app/src/test/java/dev/konraditurbe/osmosis/drone/DroneManifestTest.kt) against
 the captured frames.


### PR DESCRIPTION
Two docs commits, no behaviour change.

## ROADMAP.md — 973 lines → 300

Two headers, `## Todo` and `## Done`, each item under exactly one. Every item states what we want plus a **Blockers:** paragraph where something actually blocks it. Dropped the rolling account of how each item was solved and the ~200-line drone history appendix — the wire formats they restated live in MEDIA_PROTOCOL.md, which each item now links to.

Item numbers are unchanged so an item keeps its number when it moves lists. New `#18` collects the drone work the Mavic 3 item was carrying as open questions.

**Reference direction reversed:** no `.kt` file cites a roadmap item any more, and neither do the protocol docs. All 21 sites now point at the MEDIA_PROTOCOL section carrying the bytes, or at the implementing class. A roadmap entry describes intent and moves; a protocol section describes the wire and doesn't.

## MEDIA_PROTOCOL.md — corrected against the fixtures, and rewritten as a spec

Claims were re-derived from the five manifest fixtures and a Pocket 4 tester log rather than from the prose. Four were wrong:

- `0x02/0xdc` two-store bodies are **40 B, not 32** (`xtra_13.bin`). The code's `>= 32` test is a "second block present" gate, not a length, and now says so.
- Byte 0 of that frame was documented as an inverted card-present flag. A card-less Nano reads `0x00` and a card-less Xtra `0x11` — it tracks neither.
- The star byte is **Nano-only**; on the Action family it is a length reading 44/48, so a `!= 0` test marks every file starred. Table of all five fixtures added.
- `GetWifiPassword`'s timing note cross-referenced the battery section.

Newly **confirmed rather than assumed**: the Pocket 3's SD handle base, from `op3_15.bin` (`0x00040010`–`0x000400f0`). Pocket 4 row added from a tester log.

Documented the **per-store split**: the cursor's top bit selects the store, and each `0x00/0x27` chunk echoes the request counter at sub-header byte 4, so one blob separates into two labelled answers with no extra query and no HTTP `HEAD`.

Rewrote the **playback-hold** section as an ordered procedure — the camera drops the mode ~1 s after it is set unless the client beats at ~1 Hz. Plus `0x04/0x05` as the gimbal-alive signal, the short-page end-of-list rule, and the ~40–70 s inline-write window.

Throughout, the document now reads as an implementation reference for someone writing their own client: no first-person, no project history, no account of what we broke on the way.

Redacted a tester's drone serial from a log excerpt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)