### PR TITLE
Activation detection

### DIFF
--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
@@ -216,6 +216,18 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
     // is the fallback for models that don't answer.
     private var credsRequested = false
 
+    /** DJI's `LctActivateState`, off the camera's own 0x00/0x32 push. -1 until it says. */
+    private var activateState = -1
+
+    /** DJI's `LctActivateState` enum, from Mimo's `LctActivateState.java`. */
+    private fun activateStateName(s: Int) = when (s) {
+        0 -> "not activated"; 1 -> "activated"; 2 -> "uninitialized"; 3 -> "factory activated"
+        0xFFFE -> "not supported"; else -> "unknown ($s)"
+    }
+
+    /** True only when the camera has said, in its own words, that it isn't activated yet. */
+    private fun saysNotActivated() = activateState == 0 || activateState == 2
+
     // The Osmo 360 AP is marked WPA3-SAE, but some phones (e.g. Android 10 tablets) fail to SAE-join
     // it; on that failure we retry the same AP as WPA2 once before giving up. One-shot per offload.
     private var wpa3FallbackDone = false
@@ -584,7 +596,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         wifiUp = false; datalinkStarted = false; wifiRejoins = 0; resumeDownloadOnRejoin = false
         // close() above cancels the gatt callback, so onDisconnected won't fire to reset these — do it
         // here, or the next camera's pairing/REQ replies get mis-deduped against the last camera's state.
-        lastPairStatus = -99; credsRequested = false; reqSeen.clear()
+        lastPairStatus = -99; credsRequested = false; activateState = -1; reqSeen.clear()
         setConnectProgress(0)
     }
 
@@ -652,6 +664,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         offloadMode = true
         offloadTriggered = false
         credsRequested = false
+        activateState = -1
         wpa3FallbackDone = false
         connecting = true
         setConnectProgress(3) // tap → connecting
@@ -672,6 +685,22 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         getSharedPreferences("osmosis", MODE_PRIVATE).getString("pass_$addr", "") ?: ""
 
     /** Per-camera password capture (keyed by MAC). SSID comes from the BLE device name. */
+    /**
+     * Shown instead of the password prompt when the camera reports it has never been activated
+     * ([saysNotActivated]) — it keeps its WiFi off, so there is no network any password would reach.
+     *
+     * There is no Activate button because there is nothing we could put behind it: activation is a
+     * challenge-response the camera answers only to DJI's servers (0x00/0x32, see the protocol map),
+     * so pointing at Mimo is the honest answer rather than a placeholder.
+     */
+    private fun showNotActivated() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.camera_not_activated_title, pillName()))
+            .setMessage(R.string.camera_not_activated_message)
+            .setPositiveButton(android.R.string.ok, null)
+            .show()
+    }
+
     private fun promptPasswordFor(addr: String, onSaved: () -> Unit) {
         val prefs = getSharedPreferences("osmosis", MODE_PRIVATE)
         val input = EditText(this).apply {
@@ -821,6 +850,14 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         main.postDelayed({
             if (offloadTriggered) return@postDelayed
             val addr = currentAddress
+            // A camera that has never been activated keeps its WiFi off — there is no AP to join and no
+            // password that would help — and it says so itself, in the 0x00/0x32 state push read below.
+            // Show what's actually wrong rather than a password prompt for a network that doesn't exist.
+            if (saysNotActivated()) {
+                logLine("Camera is ${activateStateName(activateState)} — it has never been activated, so it has no WiFi AP to join.")
+                showNotActivated()
+                return@postDelayed
+            }
             when {
                 offloadPass.isNotEmpty() -> { logLine("No BLE creds — using the saved password."); maybeStartOffload() }
                 addr != null -> { logLine("No BLE creds — asking for the password."); promptPasswordFor(addr) { offloadPass = savedPassFor(addr); maybeStartOffload() } }
@@ -1793,6 +1830,21 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
                 else -> logLine("CMD07 <- 0x07/%02x  [%s]".format(parsed.cmdId, p.toHex()))
             }
             return
+        }
+
+        // The camera volunteers its own activation state, once a second, until it is activated —
+        // 0x00/0x32 (AMT.OneTimeVerify), sub-command 0x33, state byte at 20, then a length-prefixed
+        // serial. Measured against an HCI snoop of a factory-fresh Nano being activated: 155 of these
+        // before, and the push stops dead afterwards. The values are DJI's own LctActivateState.
+        if (parsed != null && parsed.cmdSet == 0x00 && parsed.cmdId == 0x32) {
+            val p = parsed.payload
+            if (p.size >= 21 && p[0].toInt() == 0x33 && p[1].toInt() == 0x33) {
+                val st = p[20].toInt() and 0xFF
+                if (st != activateState) {
+                    activateState = st
+                    logLine("Activation state: ${activateStateName(st)}")
+                }
+            }
         }
 
         // A drone tunnels its identity beacon inside 0x51/0x01 — and sends it over BLE too, long before

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,8 @@
     <string name="loading_burst">Loading burst…</string>
     <string name="not_connected">Not connected</string>
     <string name="no_media_found">%1$s has no media on it</string>
+    <string name="camera_not_activated_title">%1$s is a brand new camera, not activated</string>
+    <string name="camera_not_activated_message">Activate it once in DJI Mimo. Unfortunately this step is mandatory, then you can delete Mimo.</string>
 
     <!-- Date headers -->
     <string name="today">TODAY</string>

--- a/docs/01-protocol-map.md
+++ b/docs/01-protocol-map.md
@@ -148,6 +148,52 @@ The AP **sleeps when idle** and must be woken per session this way. IP: camera `
 gets `192.168.2.x` via DHCP. Security: **WPA2-PSK** on Nano and Xtra (WPA3-SAE on the 360, *inferred*),
 5.8 GHz.
 
+### 5b-2. A camera that has never been activated has no AP at all
+
+Out of the box, before anyone activates it, a camera pairs and talks normally over BLE and **keeps its
+WiFi off**. Measured on a factory-fresh Osmo Nano:
+
+| probe | unactivated Nano | activated Xtra |
+|-------|------------------|----------------|
+| `07/07` GetWifiSsid | *no reply* | `"OsmoNano-5A31"` after activation |
+| `07/0e` GetWifiPassword | *no reply* | answers |
+| `07/0c` GetWifiMac | *no reply* | answers |
+| `07/19` GetCountryCode | `00 FF 46 46 00` — ASCII `"FF"` | `00 FF 45 53 00` — `"ES"` |
+| `07/41` Wifi.OpenWifi | **accepted, status `00`, no AP appears** | — |
+| `07/39` WiFi Get Work Mode | `e0` (INVALID_CMD) | `e0` |
+
+So receiver 0x07 is alive and answering on the merits — the AP is what activation gates, not the
+credential getters, and no 0x07 command brings it up. There is nothing to join and no password that
+would help. Do not offer a password prompt in this state.
+
+**Do not** use credential silence alone as the tell: an activated Xtra withheld all three while
+pushing `0x00/0x99` at ~52/s.
+
+### 5b-3. Activation itself — `0x00/0x32` (AMT.OneTimeVerify)
+
+From an HCI snoop of the official app activating a factory-fresh Nano. The sub-command is payload
+byte 0 (repeated in byte 1).
+
+| sub | dir | size | contents |
+|-----|-----|------|----------|
+| `0x33` | ← | 55 B | **state push, 1 Hz** — `[33 33][18×00][state:1][len:1][serial]` |
+| `0x35` | → | 135 B | body serial + a step counter (`0x22` before the write, `0x24` after) |
+| `0x36` | ← | 154 B | per component: type byte (`08`, `0a`), component serial, **16-byte challenge** |
+| `0x37` | → | 256 B | same component + an 18-digit token + the **16-byte response** |
+
+`state` is DJI's `LctActivateState`: `0` not activated, `1` activated, `2` uninitialized, `3` factory
+activated, `0xFFFE` not supported. A factory-fresh Nano pushes `02`; an Xtra in normal use pushes `01`.
+**The push stops the moment the camera is activated** — 155 of them before, 1 after.
+
+The camera issues a random 16-byte challenge and the app returns a 16-byte response, so the material
+is minted by DJI's server (Mimo's `ActivateProto` wraps it as `ActivationResponse.contents[]`, a
+repeated bytes field — two entries here, one per component). **Activation cannot be forged offline.**
+
+Immediately afterwards the app sets the region — `07/18 SetCountryCode`, payload `FF <cc:2> 00`, e.g.
+`ff 45 53 00`, reply `00`. Which of the two actually releases the AP is **still unknown**: both
+happened within a second of each other. Worth one probe on the next factory-fresh body, because
+`07/18` is unsigned and we can send it ourselves.
+
 ### 5c. Join from Android
 
 - API 29+ **`WifiNetworkSpecifier`** → `ConnectivityManager.requestNetwork(...)` with a


### PR DESCRIPTION
When a brand new camera connects to Osmosis there's not much we can do to activate it because the activation flow stupidly relies on DJI's servers (the camera mints a challenge, Mimo sends the challenge to DJI, DJI returns back some crypto for the cam to eat up). If we detect an unactivated camera, throw an alert warning the user to (unfortunately) download Mimo and do the activation step.