### PR TITLE
Delete/Favorite working on Mavic 3

### DIFF
--- a/app/src/main/java/dev/konraditurbe/osmosis/core/CameraFile.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/core/CameraFile.kt
@@ -112,8 +112,21 @@ data class CameraFile(
     /** DCF-index-addressed media, fetched over `/v1` rather than by path over `/v2`. */
     val isIndexed: Boolean get() = fileIndex != 0L
 
-    /** True once the manifest yielded a delete handle for this file (see DatalinkClient.deleteFiles). */
-    val deletable: Boolean get() = handle != 0L && !handleShared
+    /**
+     * The value a delete/favourite command addresses this file by: a path camera's manifest [handle],
+     * or a DCF device's packed [fileIndex]. The two share a command (`0x00/0x28`, `0x02/0xbf`) and a
+     * payload slot — only the number in it differs — so the UI treats them uniformly. 0 when neither
+     * exists: a Pocket 3 still with no marker, which stays non-deletable.
+     */
+    val opHandle: Long get() = if (handle != 0L) handle else if (isIndexed) fileIndex else 0L
+
+    /**
+     * Deletable when it has an address the delete command can name and nothing disqualifies it. For a
+     * path camera that is a manifest [handle] not shared with another file; for a DCF device it is the
+     * always-present, always-unique [fileIndex]. A favourite-only fitted [cmdHandle] never makes a file
+     * deletable — delete stays on verified addresses.
+     */
+    val deletable: Boolean get() = opHandle != 0L && !handleShared
 
     val name: String get() = path.substringAfterLast('/')
     val ext: String get() = name.substringAfterLast('.', "").uppercase()

--- a/app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/dcf/DcfRecords.kt
@@ -15,6 +15,7 @@ data class DcfRecord(
     val sizeBytes: Long,
     val durationSec: Int,
     val mtimeEpoch: Long,
+    val starred: Boolean = false,
 ) {
     val storage: Int get() = DcfIndex.storage(fileIndex)
 
@@ -34,6 +35,7 @@ data class DcfRecord(
             durationSec = durationSec,
             mtimeEpoch = mtimeEpoch,
             storage = storage,
+            starred = starred,
         )
     }
 }
@@ -93,9 +95,13 @@ object DcfRecords {
      * +4  u32  file size in bytes    — verified byte-exact against two HTTP Content-Lengths
      * +8  u32  file_index, packed    — see [DcfIndex]
      * +12 u16  duration in seconds; 0 => still photo
+     * +19 u8   favourite flag: 1 = starred — the byte right after the constant `4c 03` pair
      * ```
-     * Fields past `+14` are not yet mapped (resolution/fps live in there somewhere) and are left null
-     * rather than guessed.
+     * The favourite flag is **hardware-verified on the Mavic 3**: three files favourited in DJI Fly
+     * (580, 585, 590) read `01` here and the seven around them `00`, videos and stills alike. Other
+     * fields past `+14` (resolution/fps) are not yet mapped and are left null rather than guessed. The
+     * flag is read wherever the stride reaches it; on a body that puts it elsewhere the worst case is a
+     * cosmetic wrong heart, never a wrong file — so it is not gated to the Mavic.
      *
      * Trailing partial records are dropped, as is any record whose index fails [DcfIndex.isPlausible] —
      * a missing middle chunk shifts the stream out of phase, and returning the records we can trust
@@ -110,7 +116,8 @@ object DcfRecords {
             val index = u32(blob, off + 8)
             val duration = u16(blob, off + 12)
             if (!DcfIndex.isPlausible(index) || size == 0L) continue
-            out.add(DcfRecord(index, size, duration, DcfIndex.fatToEpoch(mtime)))
+            val starred = stride > 19 && u8(blob, off + 19) == 1
+            out.add(DcfRecord(index, size, duration, DcfIndex.fatToEpoch(mtime), starred))
         }
         return out
     }

--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneManifest.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneManifest.kt
@@ -192,4 +192,37 @@ object DroneManifest {
         p[4] = (seq and 0xFF).toByte(); p[5] = ((seq shr 8) and 0xFF).toByte()
         return p
     }
+
+    private fun le32(out: java.io.ByteArrayOutputStream, v: Long) {
+        out.write((v and 0xFF).toInt()); out.write(((v shr 8) and 0xFF).toInt())
+        out.write(((v shr 16) and 0xFF).toInt()); out.write(((v shr 24) and 0xFF).toInt())
+    }
+
+    /**
+     * Favourite / unfavourite one file — DUML **`0x02/0xbf`**, addressed by packed **`file_index`**.
+     *
+     * Byte-identical to the camera's favourite payload ([CameraSession.favoritePayload]) with the index
+     * in the handle slot: `01 01 [index:u32-LE][counter:u32-LE] 00 [on] 00 00 00`. Verified byte-exact
+     * against a Mavic 3 capture (files 603 and 604 favourited in DJI Fly, 2026-08-22).
+     */
+    fun favouriteCmd(fileIndex: Long, counter: Int, on: Boolean): ByteArray =
+        java.io.ByteArrayOutputStream().apply {
+            write(0x01); write(0x01); le32(this, fileIndex); le32(this, counter.toLong())
+            write(0x00); write(if (on) 0x01 else 0x00); write(0x00); write(0x00); write(0x00)
+        }.toByteArray()
+
+    /**
+     * Delete files by packed **`file_index`** — DUML **`0x00/0x28`**, batch-capable.
+     *
+     * The camera's delete payload ([CameraSession.deletePayload]) **minus the trailing `01 01 00 00`**
+     * storage selector, which the aircraft does not send: `[count:u8][index:u32-LE × count]
+     * [counter:u32-LE] 00 [count:u32-LE]`. Verified byte-exact against a Mavic 3 capture that deleted
+     * three files (600, 601, 602) in one command. **Irreversible.**
+     */
+    fun deleteCmd(indices: List<Long>, counter: Int): ByteArray =
+        java.io.ByteArrayOutputStream().apply {
+            write(indices.size and 0xFF)
+            for (idx in indices) le32(this, idx)
+            le32(this, counter.toLong()); write(0x00); le32(this, indices.size.toLong())
+        }.toByteArray()
 }

--- a/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneSession.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/drone/DroneSession.kt
@@ -278,6 +278,63 @@ class DroneSession(
         return j.done
     }
 
+    // ---- favourite / delete (addressed by packed file_index) ---------------------------------------
+    //
+    // Both are the SAME DUML commands the path cameras use — 0x02/0xbf favourite, 0x00/0x28 delete —
+    // with the file_index sitting where a camera puts its manifest handle, and sender 0x02 → receiver
+    // 0x01, type 0x40, exactly as the camera. Reverse-engineered from a Mavic 3 capture (fav 603/604,
+    // delete 600/601/602) and built by [DroneManifest.favouriteCmd] / [deleteCmd]. One counter is
+    // shared across both, matching DJI Fly (fav 1, fav 2, delete 3).
+
+    /** Shared per-command counter for favourite/delete, like DJI Fly's. */
+    private var writeCounter = 1
+
+    /**
+     * Send a write command on the live session and wait for its `0x0000` reply.
+     *
+     * Runs on the session thread via [onDroneThread] — the keep-alive owns the socket, so a write from
+     * any other thread would be starved in the same way an un-queued page fetch was. The reply is a
+     * frame with the same set/cmd carrying a status word (`00` = OK); our own outbound frame never
+     * comes back on the receive side, so a set/cmd match in the RX stream is unambiguously the reply.
+     * Returns the status (0 = OK), or null on no reply / no session.
+     */
+    private fun droneWrite(set: Int, cmd: Int, payload: ByteArray, label: String): Int? {
+        var status: Int? = null
+        val ran = onDroneThread(8_000) {
+            sendDuml(set, cmd, payload, receiverType = 0x01, receiverId = 0)
+            log("datalink: drone $label 0x%02x/0x%02x sent".format(set, cmd))
+            val rx = java.io.ByteArrayOutputStream()
+            val deadline = System.nanoTime() + 5_000_000_000L
+            while (System.nanoTime() < deadline && status == null) {
+                dronePump(200, rx)   // keeps the uplink/beacon alive while we wait
+                sendAck()
+                for ((s, c, pl) in scanFrames(rx.toByteArray())) if (s == set && c == cmd) {
+                    status = if (pl.isEmpty()) 0
+                    else (pl[0].toInt() and 0xFF) or (if (pl.size > 1) (pl[1].toInt() and 0xFF) shl 8 else 0)
+                    break
+                }
+            }
+        }
+        if (!ran) log("datalink: drone $label — no session thread")
+        log("datalink: drone $label status=${status?.let { "0x%04x".format(it) } ?: "no reply"}")
+        return status
+    }
+
+    /** Favourite/unfavourite one file by its packed `file_index`. Returns true on `0x0000`. */
+    override fun setFavorite(handle: Long, on: Boolean): Boolean =
+        droneWrite(0x02, 0xBF, DroneManifest.favouriteCmd(handle, writeCounter++, on),
+            "FAVOURITE idx=$handle on=$on") == 0
+
+    /**
+     * Delete files by packed `file_index` — **irreversible**. One command carries the whole batch, as
+     * DJI Fly does. Returns the reply status (0 = OK), or null on no reply, matching the camera path.
+     */
+    override fun deleteFiles(handles: List<Long>): Int? {
+        if (handles.isEmpty()) return null
+        return droneWrite(0x00, 0x28, DroneManifest.deleteCmd(handles, writeCounter++),
+            "DELETE n=${handles.size}")
+    }
+
     /**
      * A drone needs the uplink stream kept running or it stops talking to us, and it wants none of the
      * camera's playback/status polling — so it gets its own loop, which doubles as the server for

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
@@ -1426,9 +1426,10 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
      *  the serialized favorite worker and reverts the badge on failure. */
     private fun toggleFavorite(f: CameraFile, dl: MediaSession) {
         val on = !f.starred
-        // Videos carry their own handle; photos don't, so fall back to the manifest-fitted one (a
-        // hardcoded Nano formula is why photo favorites failed on the Xtra). See withCmdHandles.
-        val favHandle = if (f.handle != 0L) f.handle else f.cmdHandle
+        // A drone addresses by file_index; a path camera by its manifest handle, or the manifest-fitted
+        // one for photos (a hardcoded Nano formula is why photo favorites failed on the Xtra — see
+        // withCmdHandles). opHandle covers handle and file_index; cmdHandle is the photo fallback.
+        val favHandle = if (f.opHandle != 0L) f.opHandle else f.cmdHandle
         if (favHandle == 0L) { toast(getString(R.string.favorite_no_handle, f.name)); return }
         // Optimistic badge only — the camera's manifest is the single source of truth for star state, so a
         // reload shows whatever the camera reports (the Xtra reports none; that's fine, we don't fake it).
@@ -1442,7 +1443,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
 
     /** Confirm + delete [f] from the camera (DUML 0x00/0x28) — irreversible, so it's gated by a dialog. */
     private fun confirmDelete(f: CameraFile, dl: MediaSession) {
-        val hx = "0x%08x".format(f.handle)
+        val hx = "0x%08x".format(f.opHandle)
         AlertDialog.Builder(this)
             .setTitle(R.string.delete_from_camera_title)
             .setMessage(getString(R.string.delete_from_camera_message, f.name, hx))
@@ -1451,7 +1452,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
                 logLine("DELETE requested: ${f.name} (handle $hx)")
                 toast(getString(R.string.deleting, f.name))
                 cmdExec.execute {
-                    val status = runCatching { dl.deleteFiles(listOf(f.handle)) }.getOrNull()
+                    val status = runCatching { dl.deleteFiles(listOf(f.opHandle)) }.getOrNull()
                     main.post {
                         when (status) {
                             0 -> {
@@ -1509,7 +1510,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
     }
 
     private fun runBulkDelete(files: List<CameraFile>, dl: MediaSession) {
-        val handles = files.map { it.handle }
+        val handles = files.map { it.opHandle }
         logLine("DELETE requested: ${files.size} files, handles " +
             handles.joinToString(" ") { "0x%08x".format(it) })
         toast(getString(R.string.bulk_deleting, files.size))

--- a/app/src/test/java/dev/konraditurbe/osmosis/dcf/DroneStarFlagTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/dcf/DroneStarFlagTest.kt
@@ -1,0 +1,53 @@
+package dev.konraditurbe.osmosis.dcf
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The favourite flag in a Mavic 3 record, pinned to ground truth.
+ *
+ * Six real 94-byte records straight off the aircraft (2026-08-22), three of files favourited in DJI
+ * Fly (580, 585, 590) and three not (581, 584, 589) — a video and a still on each side. The flag is
+ * the byte at `+19`, the one right after the constant `4c 03` pair: `01` on every favourite, `00` on
+ * every other, for both media kinds. See [DcfRecords.decodeDrone].
+ */
+class DroneStarFlagTest {
+
+    // file number (index & 0xFFFF) -> full record hex, from the STARPROBE capture.
+    private val records = linkedMapOf(
+        580 to "93100d5d3b59870e440264000e000310034c030101d22be18e040000000100070010000e000304db2a270100000000000000000f00000000000000000b000000000000000000000000000000000000000000000000000000000000000000",
+        581 to "a2100d5dce5af3114502640012000310034c030001d6c376a80400000001000700100012000304e74d660100000000000000000f00000000000000000b000000000000000000000000000000000000000000000000000000000000000000",
+        584 to "d8100d5d9932dd0a480264000a000310034c03000137fcad81040000000100070010000a000304e96ed90000000000000000000f00000000000000000b000000000000000000000000000000000000000000000000000000000000000000",
+        585 to "ef100d5d3138b2184902640019000310034c030101743e26ee0400000001000700100019000304766fea0100000000000000000f00000000000000000b000000000000000000000000000000000000000000000000000000000000000000",
+        589 to "fc100d5d0060a4004d02640000000000004c03000201000008ff01000000f0000000180100006400000002006400f9ffffff0a00000001000000180016000000000b00000000000000000000000000000000000000000000000000000000",
+        590 to "0e110d5d0070f8004e02640000000000004c03010201000008ff010000001e000000180100006400000002006400f9ffffff0a00000001000a00180016000000000b00000000000000000000000000000000000000000000000000000000",
+    )
+
+    private fun bytes(hex: String) = hex.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    private fun blob() = records.values.joinToString("").let(::bytes)
+
+    @Test fun `every record is 94 bytes`() {
+        for ((n, h) in records) assertEquals("file $n", 94, h.length / 2)
+    }
+
+    @Test fun `favourited files read starred, the rest do not`() {
+        val fav = setOf(580, 585, 590)
+        val decoded = DcfRecords.decodeDrone(blob(), stride = 94).associateBy { (it.fileIndex and 0xFFFF).toInt() }
+        assertEquals("all six records decode", 6, decoded.size)
+        for (n in records.keys) {
+            val starred = decoded.getValue(n).starred
+            if (n in fav) assertTrue("file $n should be starred", starred)
+            else assertFalse("file $n should not be starred", starred)
+        }
+    }
+
+    @Test fun `the flag survives projection to CameraFile`() {
+        val byNum = DcfRecords.decodeDrone(blob(), stride = 94)
+            .associateBy { (it.fileIndex and 0xFFFF).toInt() }
+        assertTrue(byNum.getValue(590).toCameraFile().starred)   // a favourited still
+        assertFalse(byNum.getValue(589).toCameraFile().starred)  // the still next to it
+    }
+}

--- a/app/src/test/java/dev/konraditurbe/osmosis/drone/DroneWriteCmdTest.kt
+++ b/app/src/test/java/dev/konraditurbe/osmosis/drone/DroneWriteCmdTest.kt
@@ -1,0 +1,46 @@
+package dev.konraditurbe.osmosis.drone
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The drone favourite and delete payloads, pinned byte-for-byte to a Mavic 3 capture
+ * (`PCAPdroid_22_Aug_14_38_28`, 2026-08-22): files 603 and 604 favourited and 600/601/602 deleted in
+ * DJI Fly, addressed by packed `file_index`. The commands are the camera's own — `0x02/0xbf` and
+ * `0x00/0x28` — so the only thing that can drift is the byte layout, which is what this locks.
+ */
+class DroneWriteCmdTest {
+
+    private fun hex(b: ByteArray) = b.joinToString("") { "%02x".format(it) }
+
+    // Packed indices from the capture: dir 100, files 604/603 and 602/601/600.
+    private val f604 = 0x0064025cL
+    private val f603 = 0x0064025bL
+    private val f602 = 0x0064025aL
+    private val f601 = 0x00640259L
+    private val f600 = 0x00640258L
+
+    @Test fun `favourite payload matches the wire, counters 1 and 2`() {
+        assertEquals("01015c026400010000000001000000", hex(DroneManifest.favouriteCmd(f604, 1, on = true)))
+        assertEquals("01015b026400020000000001000000", hex(DroneManifest.favouriteCmd(f603, 2, on = true)))
+    }
+
+    @Test fun `unfavourite flips only the on byte`() {
+        assertEquals("01015c026400010000000000000000", hex(DroneManifest.favouriteCmd(f604, 1, on = false)))
+    }
+
+    @Test fun `three-file delete matches the wire, counter 3`() {
+        assertEquals(
+            "035a0264005902640058026400030000000003000000",
+            hex(DroneManifest.deleteCmd(listOf(f602, f601, f600), 3)),
+        )
+    }
+
+    /** The drone delete is the camera's minus the trailing `01 01 00 00` storage selector — a
+     *  single-file delete must therefore be four bytes shorter and not end in that trailer. */
+    @Test fun `single delete has no storage-selector trailer`() {
+        val p = hex(DroneManifest.deleteCmd(listOf(f604), 1))
+        assertEquals("015c026400010000000001000000", p)
+        assert(!p.endsWith("01010000")) { "drone delete must not carry the camera's storage trailer" }
+    }
+}


### PR DESCRIPTION
Write command logic for Mavic 3 DCF paths. Same command as cameras but with fileIndex inside.