### PR TITLE
Show prompt to download DNG/WAV files if present

### DIFF
--- a/MEDIA_PROTOCOL.md
+++ b/MEDIA_PROTOCOL.md
@@ -569,6 +569,20 @@ the neighbouring modes: ~96 Mbit/s, 127 MB for 10 s, against 42 MB for 9 s of 4K
 | `[19:23]` | u32-LE   | video UUID (Amba `DjiMovDmx`) |
 | `[38:42]` | u32-LE   | size-ish (~KB; a photo record reads ~0.6 MB) |
 
+### 1a. Unlisted sidecar files (RAW `.DNG` / audio-backup `.WAV`)
+
+Two shooting modes leave a **second file on the card that the manifest never lists**: a RAW `.DNG`
+beside a still shot in JPEG+RAW, and a `.WAV` audio backup beside a clip recorded with Built-In Mic
+Audio Backup. Both sit at the **same path as their parent with the extension swapped**, on the same
+store, and are served over `/v2` exactly like any other file:
+
+```
+GET /v2?storage=1&path=DCIM/CAM_001/CAM_20260822234658_0073_D.DNG   -> 200, 80,332,744 B
+GET /v2?storage=1&path=DCIM/CAM_001/CAM_20260822234724_0075_D.WAV   -> 200,    925,740 B
+```
+
+**There is no manifest flag for either.**
+
 ### 2. Delete media
 - Cmd Set / ID: `0x00` / `0x28`  ·  App → Camera(`0x01`), datalink  ·  **irreversible on the card**
 - Payload: `[count:u8][handle:u32-LE × count][seq:u32-LE] · 00 · [count:u32-LE] 01 01 00 00`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -111,27 +111,3 @@ approval dialog. `PcapAnalysis` rides along on both for reading a capture with o
 
 **Blockers:** hardware. Both branches are instrumentation waiting for one run each — nothing more can
 be deduced from what we have.
-
-### 19. DNG / sidecar file download:
-
-Allow downloading sidecar files such as DNG photos, audio files, etc...
-
-Need to do research on what sort of files can acompany each video/photo.
-
-- Video: 
-
-"Audio backup" / "Built In Mic Audio Backup" feature on Xtra Edge Pro/Osmo Nano.
-
-- Photo:
-
-DNG sidecar file when shooting in JPEG+DNG mode
-
-UI:
-
-"Add to queue" button remains one button, clicking adding to queue prompts to also append to the queue the sidecar file.
-
-**Sidecar file detected**
-
-Want to add (DNG/AAC/XXX) file to the queue as well?
-
-*Yes / no*

--- a/app/src/main/java/dev/konraditurbe/osmosis/core/CameraFile.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/core/CameraFile.kt
@@ -181,6 +181,27 @@ data class CameraFile(
     val isPanorama: Boolean get() = mediaType == MediaFileType.PANORAMA
     val isImage: Boolean get() = ext in setOf("JPG", "JPEG", "DNG", "HEIC", "RAW")
 
+    /**
+     * The unlisted companion file that *might* sit beside this one — a RAW `.DNG` for a still shot in
+     * JPEG+RAW, or an audio-backup `.WAV` for a clip recorded with Built-In Mic Audio Backup. It shares
+     * this file's path with the extension swapped and is served over the same `/v2` mount, but the
+     * manifest carries no flag for it (candidate bytes were disproven — they fire on burst leads too),
+     * so a caller confirms it with one HTTP HEAD before offering it. Null for types that never have one.
+     * [sizeBytes] is 0 until the HEAD fills it in; [handle] is cleared (a sidecar isn't independently
+     * deletable). See ROADMAP #19 / MEDIA_PROTOCOL §19.
+     */
+    fun sidecarCandidate(): CameraFile? {
+        val kind = when (ext) {
+            "JPG", "JPEG" -> "DNG"
+            "MP4", "MOV" -> "WAV"
+            else -> return null
+        }
+        return copy(
+            path = path.substringBeforeLast('.', path) + ".$kind",
+            handle = 0L, handleShared = false, handleCandidate = 0L, sizeBytes = 0L,
+        )
+    }
+
     companion object {
         /**
          * Marks a thumbnail that has to be lifted out of the original's EXIF block rather than fetched

--- a/app/src/main/java/dev/konraditurbe/osmosis/net/MediaDownloader.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/net/MediaDownloader.kt
@@ -250,10 +250,15 @@ class MediaDownloader(
 
     // ---- MediaStore plumbing ------------------------------------------------
 
+    // Collection + folder are keyed on isVideo/isImage (a DNG raw counts as an image, so it lands in
+    // Pictures next to its JPEG); only the MIME is refined per extension so a raw or an audio-backup
+    // sidecar is stored as what it actually is. downloadedUri mirrors the collection/folder choice.
     private fun collectionFor(f: CameraFile): Triple<Uri, String, String> = when {
         f.isVideo -> Triple(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, "Movies/Osmosis", "video/mp4")
-        f.isImage -> Triple(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "Pictures/Osmosis", "image/jpeg")
-        else -> Triple(MediaStore.Downloads.EXTERNAL_CONTENT_URI, "Download/Osmosis", "application/octet-stream")
+        f.isImage -> Triple(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "Pictures/Osmosis",
+            if (f.ext == "DNG") "image/x-adobe-dng" else "image/jpeg")
+        else -> Triple(MediaStore.Downloads.EXTERNAL_CONTENT_URI, "Download/Osmosis",
+            if (f.ext == "WAV") "audio/x-wav" else "application/octet-stream")
     }
 
     private fun createPending(f: CameraFile, displayName: String): Uri? {
@@ -344,10 +349,11 @@ class MediaDownloader(
             }.getOrNull()
         }
 
-        /** MIME for a saved copy, matching what the download wrote. */
+        /** MIME for a saved copy, matching what the download wrote (see [collectionFor]). */
         fun mimeOf(file: CameraFile): String = when {
             file.isVideo -> "video/mp4"
-            file.isImage -> "image/jpeg"
+            file.isImage -> if (file.ext == "DNG") "image/x-adobe-dng" else "image/jpeg"
+            file.ext == "WAV" -> "audio/x-wav"
             else -> "application/octet-stream"
         }
     }

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MediaPreviewActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MediaPreviewActivity.kt
@@ -149,6 +149,7 @@ class MediaPreviewActivity : AppCompatActivity() {
             queued = !queued
             commitQueue()
             refreshQueueButton()
+            if (queued) offerSidecar() else dropSidecar()
         }
 
         navItems = dev.konraditurbe.osmosis.net.PreviewNav.items
@@ -259,6 +260,54 @@ class MediaPreviewActivity : AppCompatActivity() {
         else null
         val trim = if (hasTrim()) TrimRange(trimStartMs, trimEndMs) else null
         dev.konraditurbe.osmosis.net.PreviewNav.setQueued?.invoke(file.path, queued, trim, member)
+    }
+
+    /** The file the queue button actually acts on: the shown burst frame, else the current item. */
+    private fun queueTarget(): CameraFile =
+        if (groupPaths.isNotEmpty() && selectedFrame > 0)
+            file.copy(path = groupPaths[selectedFrame], thumbPath = groupThumbs.getOrNull(selectedFrame) ?: file.thumbPath)
+        else file
+
+    /**
+     * ROADMAP #19: when a queued still has an unlisted RAW (`.DNG`) beside it, or a queued clip an
+     * audio-backup (`.WAV`), offer to queue that too. The manifest carries no reliable flag for it, so
+     * confirm the companion exists with one HEAD (off the main thread) before prompting. It is queued as
+     * its own entry, carrying its own path through the queue's `member` slot so it downloads with no grid
+     * cell of its own; the HEAD's Content-Length becomes its size for the progress/duplicate checks.
+     */
+    private fun offerSidecar() {
+        val target = queueTarget()
+        val sc = target.sidecarCandidate() ?: return
+        val url = PathAddressing.byPath(target.storage, sc.path)
+        Thread {
+            val len = http.head(url)
+            if (len < 0) return@Thread                    // no companion file on the card
+            main.post {
+                if (!queued) return@post                  // user de-queued while the HEAD was in flight
+                androidx.appcompat.app.AlertDialog.Builder(this)
+                    .setTitle(R.string.sidecar_title)
+                    .setMessage(getString(R.string.sidecar_msg, sc.ext, humanSize(len)))
+                    .setPositiveButton(android.R.string.yes) { _, _ ->
+                        dev.konraditurbe.osmosis.net.PreviewNav.setQueued
+                            ?.invoke(sc.path, true, null, sc.copy(sizeBytes = len))
+                        Toast.makeText(this, getString(R.string.sidecar_added, sc.ext), Toast.LENGTH_SHORT).show()
+                    }
+                    .setNegativeButton(android.R.string.no, null)
+                    .show()
+            }
+        }.start()
+    }
+
+    /** Drop a companion when its parent is de-queued — silent, and a no-op if it was never added. */
+    private fun dropSidecar() {
+        val sc = queueTarget().sidecarCandidate() ?: return
+        dev.konraditurbe.osmosis.net.PreviewNav.setQueued?.invoke(sc.path, false, null, null)
+    }
+
+    private fun humanSize(b: Long): String = when {
+        b >= 1_000_000_000 -> "%.1f GB".format(b / 1e9)
+        b >= 1_000_000 -> "%.0f MB".format(b / 1e6)
+        else -> "%d KB".format(b / 1000)
     }
 
     /** Build the 1×n burst/interval frame strip: a thumbnail per frame, tap to view it, accent border on

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,9 @@
     <string name="remove_from_queue">Remove from Queue</string>
     <string name="already_downloaded">Already downloaded</string>
     <string name="no_preview">No preview for .%1$s</string>
+    <string name="sidecar_title">Sidecar file detected</string>
+    <string name="sidecar_msg">This item has a %1$s file beside it (%2$s). Add it to the queue as well?</string>
+    <string name="sidecar_added">%1$s added to the queue</string>
     <string name="cant_play_clip">Can\'t play this clip (%1$d/%2$d)</string>
     <string name="preview_unavailable">Preview unavailable</string>
     <string name="pause_then_set_start">Pause, then set the start point</string>


### PR DESCRIPTION
DJI Osmo cameras have a JPEG+DNG photo mode, as well as "Audio Backup" option which saves a sidecar WAV file along with the video.

Show a prompt to additionally download such sidecar files if they exist, along with the original JPEG/MP4 file.