### PR TITLE
Add app shortcuts to quickly jump into a camera

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@
         <activity
             android:name=".ui.MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:launchMode="singleTop"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/dev/konraditurbe/osmosis/core/SavedCameras.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/core/SavedCameras.kt
@@ -13,25 +13,35 @@ class SavedCameras(private val prefs: SharedPreferences) {
     fun all(): List<Entry> =
         prefs.getStringSet(KEY, emptySet()).orEmpty().mapNotNull(::parse).sortedBy { it.name.lowercase() }
 
+    /**
+     * Saved cameras ordered most-recently-connected first — drives the launcher App Shortcuts, which
+     * surface the cameras the user reaches for. Never-timestamped entries (saved before this existed)
+     * sort last in name order, since [all] is name-sorted and the sort below is stable.
+     */
+    fun recent(): List<Entry> = all().sortedByDescending { prefs.getLong(tsKey(it.mac), 0L) }
+
+    /** Save (or refresh) a camera and stamp it as just-connected, so [recent] floats it to the top. */
     fun save(mac: String, name: String, modelId: Int?) {
         val next = prefs.getStringSet(KEY, emptySet()).orEmpty()
             .filterNot { it.substringBefore('|') == mac }
             .toMutableSet()
         next.add("$mac|$name|${modelId ?: -1}")
-        prefs.edit().putStringSet(KEY, next).apply()
+        prefs.edit().putStringSet(KEY, next).putLong(tsKey(mac), System.currentTimeMillis()).apply()
     }
 
     fun remove(mac: String) {
         val next = prefs.getStringSet(KEY, emptySet()).orEmpty()
             .filterNot { it.substringBefore('|') == mac }
             .toSet()
-        prefs.edit().putStringSet(KEY, next).apply()
+        prefs.edit().putStringSet(KEY, next).remove(tsKey(mac)).apply()
     }
 
     private fun parse(s: String): Entry? {
         val p = s.split('|')
         return if (p.size >= 3) Entry(p[0], p[1], p[2].toIntOrNull() ?: -1) else null
     }
+
+    private fun tsKey(mac: String) = "cam_ts_$mac"
 
     companion object { private const val KEY = "saved_cameras" }
 }

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/CameraShortcuts.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/CameraShortcuts.kt
@@ -1,0 +1,49 @@
+package dev.konraditurbe.osmosis.ui
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import dev.konraditurbe.osmosis.R
+import dev.konraditurbe.osmosis.core.SavedCameras
+
+/**
+ * Launcher **App Shortcuts** for the paired cameras (long-press the app icon). Surfaces the cameras
+ * the user actually reaches for, newest-connected first — the same idea as a messaging app showing
+ * recent chats. Tapping one launches [MainActivity] straight into the connect flow for that camera
+ * (see [EXTRA_MAC]); with no paired cameras there are no shortcuts.
+ *
+ * Dynamic (not manifest) shortcuts, because the list is per-user and changes as cameras are onboarded
+ * or forgotten. [refresh] is called on every event that can change the set: app start, a successful
+ * connect, and forgetting a camera.
+ */
+object CameraShortcuts {
+    /** Intent extra on a shortcut launch: the BLE MAC of the camera to connect to. */
+    const val EXTRA_MAC = "shortcut_mac"
+
+    /** The launcher long-press menu only shows a handful; more than this is never seen. */
+    private const val MAX = 4
+
+    fun refresh(ctx: Context) {
+        val cap = MAX.coerceAtMost(ShortcutManagerCompat.getMaxShortcutCountPerActivity(ctx).coerceAtLeast(1))
+        val cameras = SavedCameras(ctx.getSharedPreferences("osmosis", Context.MODE_PRIVATE)).recent().take(cap)
+        val shortcuts = cameras.map { cam ->
+            ShortcutInfoCompat.Builder(ctx, "cam_${cam.mac}")
+                .setShortLabel(cam.name)
+                .setLongLabel(cam.name)
+                .setIcon(IconCompat.createWithResource(ctx, R.drawable.ic_shortcut_camera))
+                .setIntent(
+                    Intent(ctx, MainActivity::class.java).apply {
+                        action = Intent.ACTION_VIEW
+                        putExtra(EXTRA_MAC, cam.mac)
+                    }
+                )
+                .build()
+        }
+        // setDynamicShortcuts replaces the whole set, so a forgotten camera drops off and the order
+        // re-sorts by last-connected on every refresh. Guarded: some launchers/limited profiles reject
+        // the call, and a shortcut failure must never take down a connect.
+        runCatching { ShortcutManagerCompat.setDynamicShortcuts(ctx, shortcuts) }
+    }
+}

--- a/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
+++ b/app/src/main/java/dev/konraditurbe/osmosis/ui/MainActivity.kt
@@ -359,10 +359,37 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
         // Camera selector is the launch screen: show saved cameras, then scan to mark which are in
         // range and surface new ones (unless a test hook is already driving a scan/flow).
         rebuildCameraList()
+        // Keep the launcher App Shortcuts in sync with the current paired-camera set on every launch.
+        CameraShortcuts.refresh(this)
+        // App Shortcut launch: the user long-pressed the app icon and picked a paired camera. Assume
+        // it's powered on and advertising, so scan and auto-connect to that MAC — same path as a tap.
+        val shortcutMac = intent?.getStringExtra(CameraShortcuts.EXTRA_MAC)
+        if (shortcutMac != null) { autoPickMac = shortcutMac; logLine("shortcut: connect to $shortcutMac") }
         val hookDriving = intent?.getBooleanExtra("autoscan", false) == true ||
             intent?.getBooleanExtra("offload", false) == true ||
             intent?.getBooleanExtra("wifi", false) == true
-        if (!hookDriving) startCameraScan(select = true)
+        when {
+            shortcutMac != null -> main.postDelayed({ startCameraScan(select = true) }, 300)
+            !hookDriving -> startCameraScan(select = true)
+        }
+    }
+
+    /**
+     * A launcher App Shortcut was tapped while we were already running (singleTop). Tear down any live
+     * session, return to the selector, and connect to the chosen camera by MAC — see [CameraShortcuts].
+     */
+    override fun onNewIntent(intent: android.content.Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        val mac = intent.getStringExtra(CameraShortcuts.EXTRA_MAC) ?: return
+        if (dev.konraditurbe.osmosis.rsdk.GpsSyncState.locked) {
+            toast(getString(R.string.gps_active_select_blocked)); return
+        }
+        logLine("shortcut (running): connect to $mac")
+        teardownOffload()
+        switchToSelector()
+        autoPickMac = mac
+        startCameraScan(select = true)
     }
 
     override fun onDestroy() {
@@ -466,6 +493,9 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
     private data class Cam(val device: BluetoothDevice, val name: String?, val brand: Brand, val rssi: Int, val modelId: Int?, val model: CameraModel)
     private val discovered = LinkedHashMap<String, Cam>()
     private var autoPick: String? = null
+    // MAC of a camera launched from a launcher App Shortcut: connect the moment it advertises, no tap
+    // (see CameraShortcuts / onHit). Cleared once consumed.
+    private var autoPickMac: String? = null
 
     /** Scan ~4s for DJI/Xtra cameras (bonds aren't reliable for these), then feed the selector list. */
     private fun startCameraScan(select: Boolean, pick: String? = null) {
@@ -613,6 +643,7 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
                         getSharedPreferences("osmosis", MODE_PRIVATE).edit().remove("pass_${r.mac}").apply()
                         logLine("Forgot ${r.name ?: r.mac}")
                         rebuildCameraList()
+                        CameraShortcuts.refresh(this)   // drop it from the launcher shortcuts too
                     }
                 }
             }.show()
@@ -1110,7 +1141,10 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
     private fun showGrid(files: List<CameraFile>, preserveFilters: Boolean = false) {
         // Reaching here = pairing + WiFi + datalink all worked → remember this camera, show the grid.
         setConnectProgress(100) // first media in — connection complete
-        currentAddress?.let { savedCameras.save(it, offloadSsid, currentModelId) }
+        currentAddress?.let {
+            savedCameras.save(it, offloadSsid, currentModelId)
+            CameraShortcuts.refresh(this)   // just connected → float this camera to the top of the shortcuts
+        }
         switchToGrid()
         statusPill.render(pillName(), getString(R.string.connected_wifi), currentStatus, showPower = isNano())
         applyOrientationChrome()   // hide the pill if we're (re)entering the grid in landscape
@@ -1722,6 +1756,11 @@ class MainActivity : AppCompatActivity(), OsmoScanner.Listener, GattClient.Liste
             logLine("found ${model.name} [$brand] (${name ?: addr}) rssi=$rssi" +
                 if (!model.verified) "  🧪" else "")
             main.post { rebuildCameraList() }
+            // App Shortcut target just appeared — connect immediately, no tap, as onCamRowClick would.
+            if (!connecting && !btnGps.isChecked && addr.equals(autoPickMac, ignoreCase = true)) {
+                autoPickMac = null
+                main.post { onCameraChosen(device) }
+            }
         }
     }
 

--- a/app/src/main/res/drawable/ic_shortcut_camera.xml
+++ b/app/src/main/res/drawable/ic_shortcut_camera.xml
@@ -1,0 +1,20 @@
+<!-- App-shortcut icon: white full-bleed background with a blue camera glyph centered in the adaptive
+     safe zone (the launcher masks the outer edge). Blue #1976D2 on white per the design ask. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M0,0h108v108h-108z" />
+    <group
+        android:scaleX="3"
+        android:scaleY="3"
+        android:translateX="18"
+        android:translateY="18">
+        <path
+            android:fillColor="#1976D2"
+            android:pathData="M12,15.2c1.77,0 3.2,-1.43 3.2,-3.2s-1.43,-3.2 -3.2,-3.2 -3.2,1.43 -3.2,3.2 1.43,3.2 3.2,3.2zM9,2L7.17,4H4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2H9zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z" />
+    </group>
+</vector>


### PR DESCRIPTION
How it looks:

<img width="438" height="668" alt="imagen" src="https://github.com/user-attachments/assets/dff1e678-df00-410b-b874-24bfc663e133" />

Adds a new `cam_ts_[mac address]` key to save when we last connected. The shortcuts are seeded from this timestamp.